### PR TITLE
アウトラインシェーダーの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ crashlytics-build.properties
 /Output_StandaloneWindows64/
 /Output_StandaloneOSX/
 /Output_StandaloneLinux64/
+moorestech_client/.vscode/settings.json

--- a/moorestech_client/Assets/Asset/Shader/Outline.meta
+++ b/moorestech_client/Assets/Asset/Shader/Outline.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c875788543e09c4490900bd60433499
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat
@@ -1,0 +1,134 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-8349985331494795825
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 7
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Outline
+  m_Shader: {fileID: 4800000, guid: 7155b474727fe984c88533de3b909a61, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _AlphaToMask: 0
+    - _Blend: 0
+    - _BlendModePreserveSpecular: 1
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _DstBlendAlpha: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _OutlineWidth: 44
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _SrcBlendAlpha: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _OutlineColor: {r: 1, g: 0.36862746, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat
@@ -113,7 +113,7 @@ Material:
     - _GlossyReflections: 0
     - _Metallic: 0
     - _OcclusionStrength: 1
-    - _OutlineWidth: 44
+    - _OutlineWidth: 100
     - _Parallax: 0.005
     - _QueueOffset: 0
     - _ReceiveShadows: 1

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat.meta
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b90a66031b12c4047b83b2be6d7c7273
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
@@ -11,6 +11,14 @@ Shader "Unlit/Outline"
         Tags { "RenderType"="Opaque" }
         LOD 100
 
+        HLSLINCLUDE
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            CBUFFER_START(UnityPerMaterial)
+                half4 _OutlineColor;
+                float _OutlineWidth;
+            CBUFFER_END
+        ENDHLSL
+
         Pass
         {
             // アウトラインを拡張したステンシル
@@ -34,7 +42,6 @@ Shader "Unlit/Outline"
 
             struct appdata
             {
-                float2 uv : TEXCOORD0;
                 float4 positionOS: POSITION;
                 float4 normalOS: NORMAL;
                 float4 tangentOS: TANGENT;
@@ -42,19 +49,15 @@ Shader "Unlit/Outline"
 
             struct v2f
             {
-                float2 uv : TEXCOORD0;
                 float4 positionCS: SV_POSITION;
             };
-
-            float4 _OutlineColor;
-            float _OutlineWidth;
 
             v2f vert (appdata v)
             {
                 v2f o;
-                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                VertexNormalInputs vertexNormalInputs = GetVertexNormalInputs(v.normalOS.xyz, v.tangentOS);
                 
-                float3 normalWS = vertexNormalInput.normalWS;
+                float3 normalWS = vertexNormalInputs.normalWS;
                 float3 normalCS = TransformWorldToHClipDir(normalWS);
                 
                 VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
@@ -78,7 +81,7 @@ Shader "Unlit/Outline"
             Tags { "LightMode" = "FillOutlineStencil" }
             
             ColorMask 0
-            ZWrite On
+            ZWrite Off
             ZTest Always
 
             Stencil
@@ -92,11 +95,8 @@ Shader "Unlit/Outline"
             #pragma vertex vert
             #pragma fragment frag
 
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
             struct appdata
             {
-                float2 uv : TEXCOORD0;
                 float4 positionOS: POSITION;
                 float4 normalOS: NORMAL;
                 float4 tangentOS: TANGENT;
@@ -104,14 +104,12 @@ Shader "Unlit/Outline"
 
             struct v2f
             {
-                float2 uv : TEXCOORD0;
                 float4 positionCS: SV_POSITION;
             };
 
             v2f vert (appdata v)
             {
                 v2f o;
-                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
                 VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
                 o.positionCS = positionInputs.positionCS;
                 return o;
@@ -143,11 +141,8 @@ Shader "Unlit/Outline"
             #pragma vertex vert
             #pragma fragment frag
 
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
             struct appdata
             {
-                float2 uv : TEXCOORD0;
                 float4 positionOS: POSITION;
                 float4 normalOS: NORMAL;
                 float4 tangentOS: TANGENT;
@@ -155,19 +150,15 @@ Shader "Unlit/Outline"
 
             struct v2f
             {
-                float2 uv : TEXCOORD0;
                 float4 positionCS: SV_POSITION;
             };
-
-            float4 _OutlineColor;
-            float _OutlineWidth;
 
             v2f vert (appdata v)
             {
                 v2f o;
-                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                VertexNormalInputs vertexNormalInputs = GetVertexNormalInputs(v.normalOS.xyz, v.tangentOS);
                 
-                float3 normalWS = vertexNormalInput.normalWS;
+                float3 normalWS = vertexNormalInputs.normalWS;
                 float3 normalCS = TransformWorldToHClipDir(normalWS);
                 
                 VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
@@ -177,66 +168,11 @@ Shader "Unlit/Outline"
 
             half4 frag (v2f i) : SV_Target
             {
-                half4 col = _OutlineColor;
-                return col;
+                return _OutlineColor;
             }
 
             ENDHLSL
 
         }
-/*
-        Pass
-        {
-            Name "Outline"
-            Cull Front
-            ZWrite On
-
-            HLSLPROGRAM
-            #pragma vertex vert
-            #pragma fragment frag
-
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
-            struct appdata
-            {
-                //float4 vertex : POSITION;
-                float2 uv : TEXCOORD0;
-                float4 positionOS: POSITION;
-                float4 normalOS: NORMAL;
-                float4 tangentOS: TANGENT;
-            };
-
-            struct v2f
-            {
-                float2 uv : TEXCOORD0;
-                //float4 vertex : SV_POSITION;
-                float4 positionCS: SV_POSITION;
-            };
-
-            float4 _OutlineColor;
-            float _OutlineWidth;
-
-            v2f vert (appdata v)
-            {
-                v2f o;
-                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
-                
-                float3 normalWS = vertexNormalInput.normalWS;
-                float3 normalCS = TransformWorldToHClipDir(normalWS);
-                
-                VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
-                o.positionCS = positionInputs.positionCS + float4(normalCS.xy * 0.001 * _OutlineWidth, 0, 0);
-                return o;
-            }
-
-            half4 frag (v2f i) : SV_Target
-            {
-                half4 col = _OutlineColor;
-                return col;
-            }
-
-            ENDHLSL
-        }
-        */
     }
 }

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
@@ -38,8 +38,6 @@ Shader "Unlit/Outline"
             #pragma vertex vert
             #pragma fragment frag
 
-            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-
             struct appdata
             {
                 float4 positionOS: POSITION;

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader
@@ -1,0 +1,242 @@
+Shader "Unlit/Outline"
+{
+    Properties
+    {
+        _OutlineWidth ("Outline Width", float) = 0
+        _OutlineColor ("Outline Color", Color) = (0,0,0,1)
+    }
+
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 100
+
+        Pass
+        {
+            // アウトラインを拡張したステンシル
+            Tags { "LightMode" = "OutlineStencil" }
+
+            ColorMask 0
+            ZWrite Off
+
+            Stencil
+            {
+                Ref 2
+                Comp Always
+                Pass Replace
+            }
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct appdata
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionOS: POSITION;
+                float4 normalOS: NORMAL;
+                float4 tangentOS: TANGENT;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionCS: SV_POSITION;
+            };
+
+            float4 _OutlineColor;
+            float _OutlineWidth;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                
+                float3 normalWS = vertexNormalInput.normalWS;
+                float3 normalCS = TransformWorldToHClipDir(normalWS);
+                
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
+                o.positionCS = positionInputs.positionCS + float4(normalCS.xy * 0.001 * _OutlineWidth, 0, 0);
+                return o;
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                half4 col = _OutlineColor;
+                return col;
+            }
+
+            ENDHLSL
+
+        }
+
+        Pass
+        {
+            // 通常描画領域にステンシルを上書き
+            Tags { "LightMode" = "FillOutlineStencil" }
+            
+            ColorMask 0
+            ZWrite On
+            ZTest Always
+
+            Stencil
+            {
+                Ref 1
+                Comp Always
+                Pass Replace
+            }
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct appdata
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionOS: POSITION;
+                float4 normalOS: NORMAL;
+                float4 tangentOS: TANGENT;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionCS: SV_POSITION;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
+                o.positionCS = positionInputs.positionCS;
+                return o;
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                return 0;
+            }
+
+            ENDHLSL
+
+        }
+
+        Pass
+        {
+            // アウトライン描画パス
+            Tags { "LightMode" = "Outline" }
+            
+            ZWrite On
+
+            Stencil
+            {
+                Ref 2
+                Comp Equal
+            }
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct appdata
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionOS: POSITION;
+                float4 normalOS: NORMAL;
+                float4 tangentOS: TANGENT;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                float4 positionCS: SV_POSITION;
+            };
+
+            float4 _OutlineColor;
+            float _OutlineWidth;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                
+                float3 normalWS = vertexNormalInput.normalWS;
+                float3 normalCS = TransformWorldToHClipDir(normalWS);
+                
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
+                o.positionCS = positionInputs.positionCS + float4(normalCS.xy * 0.001 * _OutlineWidth, 0, 0);
+                return o;
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                half4 col = _OutlineColor;
+                return col;
+            }
+
+            ENDHLSL
+
+        }
+/*
+        Pass
+        {
+            Name "Outline"
+            Cull Front
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct appdata
+            {
+                //float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+                float4 positionOS: POSITION;
+                float4 normalOS: NORMAL;
+                float4 tangentOS: TANGENT;
+            };
+
+            struct v2f
+            {
+                float2 uv : TEXCOORD0;
+                //float4 vertex : SV_POSITION;
+                float4 positionCS: SV_POSITION;
+            };
+
+            float4 _OutlineColor;
+            float _OutlineWidth;
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                VertexNormalInputs vertexNormalInput = GetVertexNormalInputs(v.normalOS, v.tangentOS);
+                
+                float3 normalWS = vertexNormalInput.normalWS;
+                float3 normalCS = TransformWorldToHClipDir(normalWS);
+                
+                VertexPositionInputs positionInputs = GetVertexPositionInputs(v.positionOS.xyz);
+                o.positionCS = positionInputs.positionCS + float4(normalCS.xy * 0.001 * _OutlineWidth, 0, 0);
+                return o;
+            }
+
+            half4 frag (v2f i) : SV_Target
+            {
+                half4 col = _OutlineColor;
+                return col;
+            }
+
+            ENDHLSL
+        }
+        */
+    }
+}

--- a/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader.meta
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Outline.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 7155b474727fe984c88533de3b909a61
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Asset/Shader/Outline/Test.unity
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Test.unity
@@ -1,0 +1,571 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &888529988
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 888529990}
+  - component: {fileID: 888529989}
+  - component: {fileID: 888529991}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &888529989
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888529988}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &888529990
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888529988}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &888529991
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 888529988}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 3
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_LightLayerMask: 1
+  m_RenderingLayers: 1
+  m_CustomShadowLayers: 0
+  m_ShadowLayerMask: 1
+  m_ShadowRenderingLayers: 1
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+--- !u!1001 &1088863200
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3521235185364410788, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_Name
+      value: Bush01
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -5.72
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3971676275126638806, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6539878465143867309, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7981370820125171223, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8544338418174048900, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8544338418174048900, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: b90a66031b12c4047b83b2be6d7c7273, type: 2}
+    - target: {fileID: 8911059744004178739, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8911059744004178739, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: b90a66031b12c4047b83b2be6d7c7273, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 15bcad4ee707448e28e0448a7402e63f, type: 3}
+--- !u!1 &1548837141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1548837144}
+  - component: {fileID: 1548837143}
+  - component: {fileID: 1548837142}
+  - component: {fileID: 1548837145}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &1548837142
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548837141}
+  m_Enabled: 1
+--- !u!20 &1548837143
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548837141}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &1548837144
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548837141}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1548837145
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1548837141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: 0
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    quality: 3
+    frameInfluence: 0.1
+    jitterScale: 1
+    mipBias: 0
+    varianceClampScale: 0.9
+    contrastAdaptiveSharpening: 0
+--- !u!1 &2079664861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2079664865}
+  - component: {fileID: 2079664864}
+  - component: {fileID: 2079664863}
+  - component: {fileID: 2079664862}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &2079664862
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079664861}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2079664863
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079664861}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  - {fileID: 2100000, guid: b90a66031b12c4047b83b2be6d7c7273, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2079664864
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079664861}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2079664865
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2079664861}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.966, y: 0.633, z: -6.5513935}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/moorestech_client/Assets/Asset/Shader/Outline/Test.unity
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Test.unity
@@ -123,6 +123,83 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &157821278
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 717484686930449981, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 717484686930449981, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: b90a66031b12c4047b83b2be6d7c7273, type: 2}
+    - target: {fileID: 3638638104421625418, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_Name
+      value: BirchTree01_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.92
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.86
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4122160074887017712, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241359420343643212, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7241359420343643212, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
+      propertyPath: m_Materials.Array.data[1]
+      value: 
+      objectReference: {fileID: 2100000, guid: b90a66031b12c4047b83b2be6d7c7273, type: 2}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 99787f18c05a0224f8fcbcfb754e845a, type: 3}
 --- !u!1 &888529988
 GameObject:
   m_ObjectHideFlags: 0
@@ -412,7 +489,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1548837141}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 1.38, y: 3.03, z: -12.4}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/moorestech_client/Assets/Asset/Shader/Outline/Test.unity.meta
+++ b/moorestech_client/Assets/Asset/Shader/Outline/Test.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8541e44027cf0a14c86d8a3cbd1c75eb
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/moorestech_client/Assets/Settings/URP Data.asset
+++ b/moorestech_client/Assets/Settings/URP Data.asset
@@ -17,7 +17,8 @@ MonoBehaviour:
     hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
   m_RendererFeatures:
   - {fileID: 7140735720254246358}
-  m_RendererFeatureMap: d68db2e84dfd1863d663f44f47cb376d
+  - {fileID: 9176458359454757473}
+  m_RendererFeatureMap: d68db2e84dfd186359896c27dc4ee90761f2764b4254597f
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}
@@ -132,3 +133,48 @@ MonoBehaviour:
   - {fileID: 2800000, guid: 3302065f671a8450b82c9ddf07426f3a, type: 3}
   - {fileID: 2800000, guid: 56a77a3e8d64f47b6afe9e3c95cb57d5, type: 3}
   m_Shader: {fileID: 4800000, guid: 0849e84e3d62649e8882e9d6f056a017, type: 3}
+--- !u!114 &9176458359454757473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3d386ba5cd94485973aee1479b272e, type: 3}
+  m_Name: OutlinePass
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  settings:
+    passTag: RenderObjects
+    Event: 300
+    filterSettings:
+      RenderQueueType: 0
+      LayerMask:
+        serializedVersion: 2
+        m_Bits: 4294967295
+      PassNames:
+      - OutlineStencil
+      - FillOutlineStencil
+      - Outline
+    overrideMaterial: {fileID: 0}
+    overrideMaterialPassIndex: 0
+    overrideShader: {fileID: 0}
+    overrideShaderPassIndex: 0
+    overrideMode: 1
+    overrideDepthState: 0
+    depthCompareFunction: 4
+    enableWrite: 1
+    stencilSettings:
+      overrideStencilState: 0
+      stencilReference: 0
+      stencilCompareFunction: 8
+      passOperation: 0
+      failOperation: 0
+      zFailOperation: 0
+    cameraSettings:
+      overrideCamera: 0
+      restoreCamera: 1
+      offset: {x: 0, y: 0, z: 0, w: 0}
+      cameraFieldOfView: 60


### PR DESCRIPTION
### 実装概要
- 普通の背面法だと丸々アウトラインで塗りつぶされてしまったのでステンシルを使った描画方法を採用
- 1パス目
  - アウトライン方向に膨張させてステンシルだけ書く（描画は行わない）
- 2パス目
  - 膨張させずにステンシルを書く（描画は行わない）
- 3パス目
  - アウトライン描画
- URPだとマルチパスシェーダーの扱いが特殊で、パスごとにLightModeTagを設定してあげてURPDataのRenderObjectで呼び出すといったことを行っている（今回は不透明描画後）

### パラメータ
- Outline Width アウトラインの太さ
- Outline Color アウトラインの色
- 基本Outline Widthを0にして、編集したいオブジェクトのみOutline Widthを高くすることで選択・非選択ができる想定

### 適用例
![スクリーンショット 2024-02-17 121628](https://github.com/moorestech/moorestech/assets/29250657/ff25f1a2-027e-49ae-b8d5-e56266430e57)

![スクリーンショット 2024-02-17 121637](https://github.com/moorestech/moorestech/assets/29250657/6e0eb05e-3f00-4ce5-84e5-84495d1d3def)
