### PR TITLE
一度再生が完了したスキットがもう一度再生される問題の修正

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Game/InGame/Skit/SkitFireManager.cs
+++ b/moorestech_client/Assets/Scripts/Client.Game/InGame/Skit/SkitFireManager.cs
@@ -28,6 +28,7 @@ namespace Client.Game.InGame.Skit
             _skitManager = skitManager;
             _initialHandshakeResponse = initialHandshakeResponse;
             _backgroundSkitManager = backgroundSkitManager;
+            PlayedSkitIds.AddRange(initialHandshakeResponse.PlayedSkitIds);
             ClientContext.VanillaApi.Event.SubscribeEventResponse(CompletedChallengeEventPacket.EventTag, OnCompletedChallenge);
             ClientContext.VanillaApi.Event.SubscribeEventResponse(SkitRegisterEventPacket.EventTag, OnSkitRegister);
         }
@@ -74,6 +75,8 @@ namespace Client.Game.InGame.Skit
                 if (action.ChallengeActionType != ChallengeActionElement.ChallengeActionTypeConst.playSkit) continue;
                 
                 var param = (PlaySkitChallengeActionParam)action.ChallengeActionParam;
+                if (PlayedSkitIds.Contains(param.SkitAddressablePath)) continue;
+                
                 skitActions.Add(param);
             }
             

--- a/moorestech_client/Assets/Scripts/Client.Network/API/Responses.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/Responses.cs
@@ -22,6 +22,7 @@ namespace Client.Network.API
         public List<ChallengeCategoryResponse> Challenges { get; }
         public UnlockStateResponse UnlockState { get; }
         public CraftTreeResponse CraftTree { get; }
+        public List<string> PlayedSkitIds { get; }
         
         public InitialHandshakeResponse(
             ResponseInitialHandshakeMessagePack initialHandshake,
@@ -31,7 +32,8 @@ namespace Client.Network.API
                 PlayerInventoryResponse inventory,
                 List<ChallengeCategoryResponse> challenges, 
                 UnlockStateResponse unlockState,
-                CraftTreeResponse craftTree) responses)
+                CraftTreeResponse craftTree,
+                List<string> playedSkitIds) responses)
         {
             PlayerPos = initialHandshake.PlayerPos;
             WorldData = responses.worldData;
@@ -40,6 +42,7 @@ namespace Client.Network.API
             Challenges = responses.challenges;
             UnlockState = responses.unlockState;
             CraftTree = responses.craftTree;
+            PlayedSkitIds = responses.playedSkitIds;
         }
     }
     

--- a/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
+++ b/moorestech_client/Assets/Scripts/Client.Network/API/VanillaApiWithResponse.cs
@@ -39,7 +39,8 @@ namespace Client.Network.API
                 GetPlayerInventory(playerId, ct), 
                 GetChallengeResponse(ct), 
                 GetUnlockState(ct), 
-                GetCraftTree(playerId, ct));
+                GetCraftTree(playerId, ct),
+                GetPlayedSkitIds(ct));
             
             return new InitialHandshakeResponse(initialHandShake, responses);
         }
@@ -164,6 +165,14 @@ namespace Client.Network.API
             }
             
             return new CraftTreeResponse(craftTreeNodes, response.CurrentTargetNode);
+        }
+        
+        public async UniTask<List<string>> GetPlayedSkitIds(CancellationToken ct)
+        {
+            var request = new GetPlayedSkitIdsProtocol.RequestGetPlayedSkitIdsMessagePack();
+            var response = await _packetExchangeManager.GetPacketResponse<GetPlayedSkitIdsProtocol.ResponseGetPlayedSkitIdsMessagePack>(request, ct);
+            
+            return response.PlayedSkitIds;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.Challenge/ChallengeDatastore.cs
+++ b/moorestech_server/Assets/Scripts/Game.Challenge/ChallengeDatastore.cs
@@ -212,7 +212,7 @@ namespace Game.Challenge
                 currentChallenges.AddRange(CollectAndExecuteInitializeChallenges());
             }
             
-            CurrentChallengeInfo = new CurrentChallengeInfo(currentChallenges, completedChallengeElements);
+            CurrentChallengeInfo = new CurrentChallengeInfo(currentChallenges, completedChallengeElements, challengeJsonObject.PlayedSkitIds);
             
             #region Internal
             
@@ -333,11 +333,11 @@ namespace Game.Challenge
         public List<ChallengeMasterElement> CompletedChallenges { get; }
         public List<string> PlayedSkitIds { get; }
         
-        public CurrentChallengeInfo(List<IChallengeTask> currentChallenges, List<ChallengeMasterElement> completedChallenges)
+        public CurrentChallengeInfo(List<IChallengeTask> currentChallenges, List<ChallengeMasterElement> completedChallenges, List<string> playedSkitIds)
         {
             CurrentChallenges = currentChallenges;
             CompletedChallenges = completedChallenges;
-            PlayedSkitIds = new List<string>();
+            PlayedSkitIds = playedSkitIds;
         }
         
         public CurrentChallengeInfo()

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetPlayedSkitIdsProtocol.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetPlayedSkitIdsProtocol.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using Game.Challenge;
+using MessagePack;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Server.Protocol.PacketResponse
+{
+    public class GetPlayedSkitIdsProtocol : IPacketResponse
+    {
+        public const string ProtocolTag = "va:getPlayedSkitIds";
+        private readonly ChallengeDatastore _challengeDatastore;
+        
+        public GetPlayedSkitIdsProtocol(ServiceProvider serviceProvider)
+        {
+            _challengeDatastore = serviceProvider.GetService<ChallengeDatastore>();
+        }
+        
+        public ProtocolMessagePackBase GetResponse(List<byte> payload)
+        {
+            return new ResponseGetPlayedSkitIdsMessagePack(_challengeDatastore.CurrentChallengeInfo.PlayedSkitIds);
+        }
+        
+        [MessagePackObject]
+        public class RequestGetPlayedSkitIdsMessagePack : ProtocolMessagePackBase
+        {
+            public RequestGetPlayedSkitIdsMessagePack()
+            {
+                Tag = ProtocolTag;
+            }
+        }
+        
+        [MessagePackObject]
+        public class ResponseGetPlayedSkitIdsMessagePack : ProtocolMessagePackBase
+        {
+            [Key(2)] public List<string> PlayedSkitIds;
+            
+            [Obsolete("デシリアライズ用のコンストラクタです。基本的に使用しないでください。")]
+            public ResponseGetPlayedSkitIdsMessagePack() {}
+            
+            public ResponseGetPlayedSkitIdsMessagePack(List<string> playedSkitIds)
+            {
+                Tag = ProtocolTag;
+                PlayedSkitIds = playedSkitIds;
+            }
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetPlayedSkitIdsProtocol.cs.meta
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponse/GetPlayedSkitIdsProtocol.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0113d901ecc840aab72a1e686e074146
+timeCreated: 1759165387

--- a/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
+++ b/moorestech_server/Assets/Scripts/Server.Protocol/PacketResponseCreator.cs
@@ -45,6 +45,7 @@ namespace Server.Protocol
             _packetResponseDictionary.Add(GetCraftTreeProtocol.ProtocolTag, new GetCraftTreeProtocol(serviceProvider));
             _packetResponseDictionary.Add(RegisterPlayedSkitProtocol.ProtocolTag, new RegisterPlayedSkitProtocol(serviceProvider));
             _packetResponseDictionary.Add(GetFluidInventoryProtocol.ProtocolTag, new GetFluidInventoryProtocol(serviceProvider));
+            _packetResponseDictionary.Add(GetPlayedSkitIdsProtocol.ProtocolTag, new GetPlayedSkitIdsProtocol(serviceProvider));
         }
         
         public List<List<byte>> GetPacketResponse(List<byte> payload)


### PR DESCRIPTION
原因はおそらく、セーブデータから読み込まれるすでに再生が完了したスキットの情報がskitfiremanagerに渡っていないことと、skitfiremanagerで再生が完了したスキットを呼ばないようにする処理がなかったことでした。
InitialHandshakeResponse内にPlayedSkitIdsを含め、セーブデータから読み込んだすでに再生が完了したスキットの情報をskitfiremanagerから読み取れるようにしました。
また、再生が完了したスキットを呼ばないようにする処理を追加しました。