### PR TITLE
fix: PR #1258レビュー指摘の鉱脈確定境界を修正

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/OreEntryPlacer.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/OreEntryPlacer.cs
@@ -24,15 +24,26 @@ namespace Game.MapGeneration.Pipeline.Generators
             SpatialGrid treeSpatialGrid,
             SpatialGrid objectSpatialGrid,
             SpatialGrid oreGrid,
-            SpatialGrid clusterCenterGrid,
-            float centerSpacing,
-            PlacementHaloChannel centerHalo,
-            List<PlacementEntry> result)
+            PlacementHaloChannelMap centerHalos,
+            float haloRadius,
+            VeinPlacementBatch result)
         {
             float w = dims.TerrainWidth;
             float l = dims.TerrainLength;
             int hRes = dims.Resolution;
             float minDist = entry.minDistanceFromOthers;
+
+            // 中心排他の設定はエントリと同じ責務に閉じる。
+            // Keeps center-exclusion setup with the entry that owns the invariant.
+            float centerSpacing = 0f;
+            if (entry.bands != null)
+                foreach (var band in entry.bands)
+                    if (band != null) centerSpacing = Mathf.Max(centerSpacing,
+                        OrePlacementMath.CalculateClusterCenterSpacing(band.clusterRadius));
+
+            var clusterCenterGrid = new SpatialGrid(w, l, Mathf.Max(w / 50f, 5f));
+            centerHalos.Get(entry.veinGuid).SeedGrid(
+                clusterCenterGrid, dims.WorldOffsetX, dims.WorldOffsetZ, w, l, haloRadius);
 
             // 地形への効き方はmapVeinsマスタが正本。veinGuidの解決はGenerationMasterのバリデーションが保証する
             // The mapVeins master owns the terrain effect; GenerationMaster validation guarantees the veinGuid resolves
@@ -101,10 +112,15 @@ namespace Game.MapGeneration.Pipeline.Generators
                             continue;
                     }
 
-                    clusterCenterGrid.Add(localX, localZ);
-                    centerHalo.Add(localX + dims.WorldOffsetX, localZ + dims.WorldOffsetZ);
+                    var cluster = new VeinPlacementCluster(
+                        entry.veinGuid, new Vector2(localX + dims.WorldOffsetX, localZ + dims.WorldOffsetZ));
+                    PlaceClusterMembers(band, localX, localZ, cluster.Members);
+                    if (cluster.Members.Count == 0) continue;
 
-                    PlaceClusterMembers(band, localX, localZ);
+                    // 実メンバーを持つ中心だけを同タイル後続候補の排他に使う。
+                    // Only centers with real members exclude later candidates in this tile.
+                    clusterCenterGrid.Add(localX, localZ);
+                    result.Clusters.Add(cluster);
                 }
             }
 
@@ -112,7 +128,8 @@ namespace Game.MapGeneration.Pipeline.Generators
 
             // クラスターメンバーを極座標で配置（ワールド整数座標にスナップ）。
             // Place cluster members in polar coordinates, snapped to integer world coordinates.
-            void PlaceClusterMembers(OreBand targetBand, float centerX, float centerZ)
+            void PlaceClusterMembers(
+                OreBand targetBand, float centerX, float centerZ, List<PlacementEntry> clusterMembers)
             {
                 int clusterCount = rng.Next(1, targetBand.maxObjectsPerCluster + 1);
                 float oreMinDist = targetBand.minDistanceBetweenOres;
@@ -139,7 +156,7 @@ namespace Game.MapGeneration.Pipeline.Generators
 
                     float my = OrePlacementMath.SampleHeight(heights, mx, mz, w, l, hRes) * dims.TerrainHeight;
 
-                    result.Add(PlacementEntry.CreateVein(
+                    clusterMembers.Add(PlacementEntry.CreateVein(
                         entry.veinGuid,
                         new Vector3(mx + dims.WorldOffsetX, my, mz + dims.WorldOffsetZ),
                         surroundEffect));

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/OrePlacementGenerator.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/OrePlacementGenerator.cs
@@ -14,7 +14,7 @@ namespace Game.MapGeneration.Pipeline.Generators
     {
         // ワールド全体の鉱脈を配置する。entryMasks[i] は entries[i] の対象バイオーム合成マスク。
         // Places all veins; entryMasks[i] is the composite biome mask for entries[i].
-        public static List<PlacementEntry> GenerateForWorld(
+        public static VeinPlacementBatch GenerateForWorld(
             OreEntry[] entries,
             bool[][,] entryMasks,
             float borderMargin,
@@ -23,11 +23,11 @@ namespace Game.MapGeneration.Pipeline.Generators
             System.Random rng,
             SpatialGrid treeSpatialGrid,
             SpatialGrid objectSpatialGrid,
-            PlacementHaloChannel memberHalo,
+            PlacementHaloChannel confirmedMemberHalo,
             PlacementHaloChannelMap centerHalos,
             float haloRadius)
         {
-            var result = new List<PlacementEntry>();
+            var result = new VeinPlacementBatch();
             if (entries == null || entries.Length == 0)
                 return result;
 
@@ -42,7 +42,7 @@ namespace Game.MapGeneration.Pipeline.Generators
 
             // 確定済みの隣タイルの鉱脈を先に入れる。木と同じく、入れないと境界の帯だけ最小距離が破られる。
             // The already-confirmed neighbouring veins go in first; as with trees, the seam band would otherwise break the minimum distance.
-            memberHalo.SeedGrid(oreGrid, dims.WorldOffsetX, dims.WorldOffsetZ, w, l, haloRadius);
+            confirmedMemberHalo.SeedGrid(oreGrid, dims.WorldOffsetX, dims.WorldOffsetZ, w, l, haloRadius);
 
             for (int i = 0; i < entries.Length; i++)
             {
@@ -50,26 +50,10 @@ namespace Game.MapGeneration.Pipeline.Generators
                 if (entry == null || string.IsNullOrEmpty(entry.veinGuid)) continue;
                 if (entryMasks == null || i >= entryMasks.Length || entryMasks[i] == null) continue;
 
-                // 中心排他はエントリ内に閉じる。全鉱脈共有だと先行エントリの中心が後続の候補を面で締め出す。
-                // Center exclusion stays within the entry; sharing across veins lets earlier entries blanket later candidates out.
-                float centerSpacing = 0f;
-                if (entry.bands != null)
-                    foreach (var band in entry.bands)
-                        if (band != null) centerSpacing = Mathf.Max(centerSpacing,
-                            OrePlacementMath.CalculateClusterCenterSpacing(band.clusterRadius));
-
-                var clusterCenterGrid = new SpatialGrid(w, l, Mathf.Max(w / 50f, 5f));
-                var centerHalo = centerHalos.Get(entry.veinGuid);
-                centerHalo.SeedGrid(clusterCenterGrid, dims.WorldOffsetX, dims.WorldOffsetZ, w, l, haloRadius);
-
                 OreEntryPlacer.Place(entry, entryMasks[i], heights, dims, rng,
                     borderPx, treeSpatialGrid, objectSpatialGrid,
-                    oreGrid, clusterCenterGrid, centerSpacing, centerHalo, result);
+                    oreGrid, centerHalos, haloRadius, result);
             }
-
-            // このタイルで確定したメンバーを次のタイルの halo へ渡す。座標は既にワールドなので補正は要らない。
-            // Hands this tile's confirmed members to the next tile's halo; the coordinates are already world-space.
-            memberHalo.AddPlacements(result, 0f, 0f);
 
             return result;
         }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/VeinPlacementBatch.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/VeinPlacementBatch.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using Game.MapGeneration.Pipeline.Config;
+using UnityEngine;
+
+namespace Game.MapGeneration.Pipeline.Generators
+{
+    // 最終確定前の鉱脈クラスターを中心とメンバーの対応付きで持つ。
+    // Holds uncommitted vein clusters while preserving the center-to-member relationship.
+    public sealed class VeinPlacementBatch
+    {
+        public readonly List<VeinPlacementCluster> Clusters = new();
+    }
+
+    public sealed class VeinPlacementCluster
+    {
+        public readonly string VeinGuid;
+        public readonly Vector2 WorldCenter;
+        public readonly List<PlacementEntry> Members = new();
+
+        public VeinPlacementCluster(string veinGuid, Vector2 worldCenter)
+        {
+            VeinGuid = veinGuid;
+            WorldCenter = worldCenter;
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/VeinPlacementBatch.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Generators/Ore/VeinPlacementBatch.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9fd253f9a233478d813a618d11122d8

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/FluidVeinPlacementStage.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/FluidVeinPlacementStage.cs
@@ -14,18 +14,20 @@ namespace Game.MapGeneration.Pipeline.Stages
         public static List<PlacedVein> Generate(
             TerrainGenerationConfig config, bool[][,] masks, BiomeType[] biomeTypes,
             float[,] heights2D, List<PlacementEntry> treeEntries, List<ObjectPlacementResult> objectPlacements,
-            IReadOnlyList<PlacedVein> itemVeins, TilePlacementContext tile)
+            TilePlacementContext tile)
         {
             var ore = config.oreConfig;
             if (!config.generateOre || ore.fluidEntries.Length == 0) return new List<PlacedVein>();
 
             // item鉱脈とは別の乱数列を使い、同一seedでも配置候補列を独立させる
             // Use a distinct random stream so item and fluid candidate sequences stay independent under the same seed
-            return VeinPlacementCore.Generate(
+            var placement = VeinPlacementCore.Generate(
                 ore.fluidEntries, ore.borderMargin,
                 config, masks, biomeTypes, heights2D, treeEntries, objectPlacements,
-                FluidVeinRngSeedOffset, itemVeins,
+                FluidVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(),
                 tile, tile.Halo.FluidVeinMembers, tile.Halo.FluidVeinCenters);
+            tile.Halo.CommitFluidVeins(placement);
+            return placement.Veins;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/OrePlacementStage.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/OrePlacementStage.cs
@@ -18,11 +18,13 @@ namespace Game.MapGeneration.Pipeline.Stages
         {
             var ore = config.oreConfig;
             if (!config.generateOre || ore.entries.Length == 0) return new List<PlacedVein>();
-            return VeinPlacementCore.Generate(
+            var placement = VeinPlacementCore.Generate(
                 ore.entries, ore.borderMargin,
                 config, masks, biomeTypes, heights2D, treeEntries, objectPlacements,
-                ItemVeinRngSeedOffset, System.Array.Empty<PlacedVein>(),
+                ItemVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(),
                 tile, tile.Halo.ItemVeinMembers, tile.Halo.ItemVeinCenters);
+            tile.Halo.CommitItemVeins(placement);
+            return placement.Veins;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinPlacementCore.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinPlacementCore.cs
@@ -12,14 +12,14 @@ namespace Game.MapGeneration.Pipeline.Stages
     // Shared placement independent of vein type
     public static class VeinPlacementCore
     {
-        public static List<PlacedVein> Generate(
+        internal static ConfirmedVeinPlacementBatch Generate(
             OreEntry[] entries, float borderMargin,
             TerrainGenerationConfig config, bool[][,] masks, BiomeType[] biomeTypes,
             float[,] heights2D, List<PlacementEntry> treeEntries, List<ObjectPlacementResult> objectPlacements,
             int rngSeedOffset, IReadOnlyList<PlacedVein> excludedVeins,
             TilePlacementContext tile, PlacementHaloChannel memberHalo, PlacementHaloChannelMap centerHalos)
         {
-            if (entries.Length == 0) return new List<PlacedVein>();
+            if (entries.Length == 0) return new ConfirmedVeinPlacementBatch();
 
             int biomeCount = biomeTypes.Length;
             int res = config.Resolution;
@@ -40,27 +40,40 @@ namespace Game.MapGeneration.Pipeline.Stages
             var dims = TerrainDimensions.From(config, 0f, tile.TileIndexX, tile.TileIndexZ);
             var rng = new System.Random(TileSeedMixer.Mix(
                 config.seed + rngSeedOffset, tile.TileIndexX, tile.TileIndexZ));
-            var members = OrePlacementGenerator.GenerateForWorld(
+            var placement = OrePlacementGenerator.GenerateForWorld(
                 entries, entryMasks, borderMargin, heights2D, dims, rng, treeGrid, objectGrid,
                 memberHalo, centerHalos, tile.Halo.Radius);
 
             // 点ごとに固定サイズの鉱脈を生成。
             // Emit one fixed-size vein per point.
-            return BuildVeins(members);
+            return BuildVeins(placement);
 
             #region Internal
 
-            List<PlacedVein> BuildVeins(List<PlacementEntry> placedMembers)
+            ConfirmedVeinPlacementBatch BuildVeins(VeinPlacementBatch generated)
             {
                 // 配置順をそのまま出力順にする
                 // The placement order becomes the output order
-                var veins = new List<PlacedVein>();
-                foreach (var member in placedMembers)
+                var confirmed = new ConfirmedVeinPlacementBatch();
+                foreach (var generatedCluster in generated.Clusters)
                 {
-                    var vein = VeinAabbBuilder.Build(member.MapObjectGuid, member.WorldPosition);
-                    if (!OverlapsExcludedVein(vein)) veins.Add(vein);
+                    var confirmedCluster = new ConfirmedVeinCluster(
+                        generatedCluster.VeinGuid, generatedCluster.WorldCenter);
+                    foreach (var member in generatedCluster.Members)
+                    {
+                        var vein = VeinAabbBuilder.Build(member.MapObjectGuid, member.WorldPosition);
+                        if (OverlapsExcludedVein(vein)) continue;
+
+                        confirmed.Veins.Add(vein);
+                        confirmedCluster.Members.Add(member);
+                    }
+
+                    // 全メンバーが除外された中心はhaloへcommitしない。
+                    // A center whose members were all excluded never commits to the halo.
+                    if (confirmedCluster.Members.Count != 0)
+                        confirmed.Clusters.Add(confirmedCluster);
                 }
-                return veins;
+                return confirmed;
             }
 
             bool OverlapsExcludedVein(PlacedVein candidate)

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
@@ -1,3 +1,8 @@
+using System.Collections.Generic;
+using Game.MapGeneration.Pipeline.Config;
+using Game.MapGeneration.Pipeline.Stages;
+using UnityEngine;
+
 namespace Game.MapGeneration.Pipeline.Tiling
 {
     // 格子1つぶんの halo 帳面。確定済みタイルの配置を種類ごとに溜め、以降のタイルの近傍判定へ供給する。
@@ -12,6 +17,7 @@ namespace Game.MapGeneration.Pipeline.Tiling
         public readonly PlacementHaloChannelMap ItemVeinCenters = new PlacementHaloChannelMap();
         public readonly PlacementHaloChannel FluidVeinMembers = new PlacementHaloChannel();
         public readonly PlacementHaloChannelMap FluidVeinCenters = new PlacementHaloChannelMap();
+        private readonly List<PlacedVein> _confirmedVeins = new();
 
         // 全制約のうち最大の距離。これを超える点はどの判定にも効かないので取り込まない。
         // The largest distance any constraint asks for; points beyond it affect no test and are never taken in.
@@ -20,6 +26,57 @@ namespace Game.MapGeneration.Pipeline.Tiling
         public PlacementHaloStore(float radius)
         {
             Radius = radius;
+        }
+
+        // 先行タイルと先行種別の確定AABBを後着鉱脈の排他入力にする。
+        // Snapshots confirmed AABBs from earlier tiles and kinds for later-vein exclusion.
+        internal List<PlacedVein> CreateConfirmedVeinSnapshot()
+        {
+            return new List<PlacedVein>(_confirmedVeins);
+        }
+
+        internal void CommitItemVeins(ConfirmedVeinPlacementBatch placement)
+        {
+            CommitVeins(placement, ItemVeinMembers, ItemVeinCenters);
+        }
+
+        internal void CommitFluidVeins(ConfirmedVeinPlacementBatch placement)
+        {
+            CommitVeins(placement, FluidVeinMembers, FluidVeinCenters);
+        }
+
+        private void CommitVeins(
+            ConfirmedVeinPlacementBatch placement,
+            PlacementHaloChannel memberHalo,
+            PlacementHaloChannelMap centerHalos)
+        {
+            // AABBと距離判定用点を同じ確定境界で一括commitする。
+            // Commits AABBs and distance-test points at the same confirmation boundary.
+            _confirmedVeins.AddRange(placement.Veins);
+            foreach (var cluster in placement.Clusters)
+            {
+                centerHalos.Get(cluster.VeinGuid).Add(cluster.WorldCenter.x, cluster.WorldCenter.y);
+                memberHalo.AddPlacements(cluster.Members, 0f, 0f);
+            }
+        }
+    }
+
+    internal sealed class ConfirmedVeinPlacementBatch
+    {
+        public readonly List<PlacedVein> Veins = new();
+        public readonly List<ConfirmedVeinCluster> Clusters = new();
+    }
+
+    internal sealed class ConfirmedVeinCluster
+    {
+        public readonly string VeinGuid;
+        public readonly Vector2 WorldCenter;
+        public readonly List<PlacementEntry> Members = new();
+
+        public ConfirmedVeinCluster(string veinGuid, Vector2 worldCenter)
+        {
+            VeinGuid = veinGuid;
+            WorldCenter = worldCenter;
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
@@ -50,9 +50,20 @@ namespace Game.MapGeneration.Pipeline.Tiling
             PlacementHaloChannel memberHalo,
             PlacementHaloChannelMap centerHalos)
         {
+            // 出力側のscene変換が台帳のnoise座標を変えないようAABB値を所有コピーする。
+            // Owns AABB values so output scene shifts cannot mutate the ledger's noise-space coordinates.
+            foreach (var vein in placement.Veins)
+            {
+                _confirmedVeins.Add(new PlacedVein
+                {
+                    VeinGuid = vein.VeinGuid,
+                    Min = vein.Min,
+                    Max = vein.Max,
+                });
+            }
+
             // AABBと距離判定用点を同じ確定境界で一括commitする。
             // Commits AABBs and distance-test points at the same confirmation boundary.
-            _confirmedVeins.AddRange(placement.Veins);
             foreach (var cluster in placement.Clusters)
             {
                 centerHalos.Get(cluster.VeinGuid).Add(cluster.WorldCenter.x, cluster.WorldCenter.y);

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/TilePlacementRunner.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/TilePlacementRunner.cs
@@ -109,7 +109,7 @@ namespace Game.MapGeneration.Pipeline.Tiling
                 itemVeins = OrePlacementStage.Generate(
                     tileConfig, masks, _biomeTypes, heights2D, treeEntries, objectPlacements, tile);
                 fluidVeins = FluidVeinPlacementStage.Generate(
-                    tileConfig, masks, _biomeTypes, heights2D, treeEntries, objectPlacements, itemVeins, tile);
+                    tileConfig, masks, _biomeTypes, heights2D, treeEntries, objectPlacements, tile);
             }
 
             void AppendMapObjects(List<PlacementEntry> entries)

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/MultiTileGenerationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/MultiTileGenerationTest.cs
@@ -139,8 +139,8 @@ namespace Tests.UnitTest.Game.MapGeneration.Tiling
             var output = new VanillaGenerator().Generate(config).Output;
 
             Assert.IsNotEmpty(output.ItemVeins);
-            MultiTileTestWorld.AssertNoOverlappingVeins(output.ItemVeins);
-            MultiTileTestWorld.AssertNoOverlappingVeins(output.FluidVeins);
+            MultiTileTestWorld.AssertNoOverlappingVeins(
+                output.ItemVeins.Concat(output.FluidVeins).ToList());
         }
 
         // シーン座標化の基準が探索の戻り値(探索無効なら0)だと、地形の窓原点だけが master worldOffset ぶん進む。

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/MultiTileGenerationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/MultiTileGenerationTest.cs
@@ -146,12 +146,23 @@ namespace Tests.UnitTest.Game.MapGeneration.Tiling
         // シーン座標化の基準が探索の戻り値(探索無効なら0)だと、地形の窓原点だけが master worldOffset ぶん進む。
         // A basis taken from the search result (zero when disabled) advances only the terrain window origin by the master worldOffset.
         [Test]
-        public void 探索無効かつmaster_worldOffsetありでも地形と配置物とスポーンが同じフレームに乗る()
+        public void 探索無効かつmaster_worldOffsetありでも地形と配置物とスポーンと鉱脈AABBが同じフレームに乗る()
         {
-            var config = MultiTileTestWorld.BuildConfig(GridSide, Seed);
+            var config = MultiTileTestWorld.BuildConfig(2, 1);
             MultiTileTestWorld.EnableTrees(config);
             config.worldOffsetX = MasterWorldOffset;
             config.worldOffsetZ = MasterWorldOffset;
+            config.oreConfig.borderMargin = 0f;
+
+            // 種類別haloだけでは防げない境界AABB候補を増やし、統一台帳の座標frameを検査する。
+            // Densify seam AABB candidates that per-kind halos cannot reject, exercising the unified ledger's coordinate frame.
+            foreach (var entry in config.oreConfig.entries.Concat(config.oreConfig.fluidEntries))
+            {
+                entry.bands[0].density = 5f;
+                entry.bands[0].maxObjectsPerCluster = 1;
+                entry.bands[0].clusterRadius = 0f;
+                entry.bands[0].minDistanceBetweenOres = 0f;
+            }
 
             // spawnWorldPosition はノイズ座標なので窓原点 + 中心タイルの1/4点に置く（シーンでは1/4点そのもの）
             // spawnWorldPosition is noise-space, so place it at the window origin plus the center tile's quarter point
@@ -177,6 +188,9 @@ namespace Tests.UnitTest.Game.MapGeneration.Tiling
             {
                 MultiTileTestWorld.AssertVeinInsideGrid(vein, config);
             }
+
+            MultiTileTestWorld.AssertNoOverlappingVeins(
+                output.ItemVeins.Concat(output.FluidVeins).ToList());
         }
     }
 }

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Vein/VeinClusterCenterSeparationTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Vein/VeinClusterCenterSeparationTest.cs
@@ -61,15 +61,28 @@ namespace Tests.UnitTest.Game.MapGeneration
             entryB.bands = new[] { CreateBand(-1f, 12f, 100f) };
             var halo = CreateHalo(40f);
 
-            // 複数bandの中心をproduction経路で生成し、中心haloから実座標を読み戻す。
-            // Generates multiple bands through production and reads their actual coordinates back from the center halo.
+            // 複数bandの実中心間隔を検証。
+            // Verifies actual center spacing across bands.
             Generate(new[] { entryA, entryB }, 0f, halo, 42);
             var centers = ReadCenters(halo, VeinGuidA, 0f);
             Assert.That(centers.Count, Is.GreaterThan(1));
-            float minimumDistance = MinimumPairDistance(centers);
+            float minimumDistance = MinimumPairDistance();
 
             Assert.That(minimumDistance, Is.GreaterThanOrEqualTo(10f));
             Assert.That(minimumDistance, Is.LessThan(30f));
+
+            #region Internal
+
+            float MinimumPairDistance()
+            {
+                float minimum = float.PositiveInfinity;
+                for (int first = 0; first < centers.Count; first++)
+                    for (int second = first + 1; second < centers.Count; second++)
+                        minimum = Mathf.Min(minimum, Vector2.Distance(centers[first], centers[second]));
+                return minimum;
+            }
+
+            #endregion
         }
 
         [Test]
@@ -138,9 +151,27 @@ namespace Tests.UnitTest.Game.MapGeneration
                 TileSize, TileSize, 100f, worldOffsetX, 0f,
                 HeightRes, 0f, 0f, 123, 0f, 0f,
                 (int)(worldOffsetX / TileSize), 0, 2, 1);
-            return OrePlacementGenerator.GenerateForWorld(
+            var placement = OrePlacementGenerator.GenerateForWorld(
                 entries, masks, 0f, new float[HeightRes, HeightRes], dims, new System.Random(seed),
                 null, null, halo.ItemVeinMembers, halo.ItemVeinCenters, halo.Radius);
+            var result = placement.Clusters.SelectMany(cluster => cluster.Members).ToList();
+            foreach (var cluster in placement.Clusters)
+                halo.ItemVeinCenters.Get(cluster.VeinGuid).Add(cluster.WorldCenter.x, cluster.WorldCenter.y);
+            halo.ItemVeinMembers.AddPlacements(result, 0f, 0f);
+            return result;
+
+            #region Internal
+
+            bool[,] CreateFullMask()
+            {
+                var mask = new bool[HeightRes, HeightRes];
+                for (int z = 0; z < HeightRes; z++)
+                    for (int x = 0; x < HeightRes; x++)
+                        mask[z, x] = true;
+                return mask;
+            }
+
+            #endregion
         }
 
         private static OreEntry CreateEntry(string veinGuid)
@@ -176,22 +207,5 @@ namespace Tests.UnitTest.Game.MapGeneration
             return grid.GetAllPoints();
         }
 
-        private static float MinimumPairDistance(IReadOnlyList<Vector2> points)
-        {
-            float minimum = float.PositiveInfinity;
-            for (int first = 0; first < points.Count; first++)
-                for (int second = first + 1; second < points.Count; second++)
-                    minimum = Mathf.Min(minimum, Vector2.Distance(points[first], points[second]));
-            return minimum;
-        }
-
-        private static bool[,] CreateFullMask()
-        {
-            var mask = new bool[HeightRes, HeightRes];
-            for (int z = 0; z < HeightRes; z++)
-                for (int x = 0; x < HeightRes; x++)
-                    mask[z, x] = true;
-            return mask;
-        }
     }
 }


### PR DESCRIPTION
## 概要

- PR #1258 の follow-up として、item/fluid 共通の確定AABB ledgerを導入し、最終filter後にだけhaloへcommitする確定境界へ揃えます。
- entryごとの中心排他セットアップを配置責務へ集約し、副作用なしbatch生成 → 最終filter → 一括commitの流れに整理します。
- `PlacedVein` のaliasによってnoise座標のledgerがscene座標変換で汚染される問題を、AABB値のdeep-copyで修正します。回帰テストはcopy無しでFAIL、copyありでPASSする赤緑を確認済みです。

## 設計上の維持事項

- AABBは既存裁定に従い `Extent = (1, 1, 1)` を維持しています。`3x1x3` には戻していません。
- item/fluidの両方が、先行タイル・先行種別を含む同じ確定済みAABB ledgerを排他入力として参照します。
- 中心haloとメンバーhaloも、最終filterで実際に残ったクラスターだけを同じ境界でcommitします。

## レビュー結果

- agents: 25/25
- Codex: 3/3
- 欠員: 0
- Critical: 6件適用
- Warning: 12件
- Info: 10件
- suppressed: 1件
- 破棄: 1件

## 事後承認対象

- 共通確定AABB ledger + 副作用なしbatch → 最終filter → 一括commit の推奨Aを暫定適用しています。

## 検証

- [x] compile: Error 0
- [x] 元適用後の関連テスト: 272/272 PASS
- [x] 追加修正後の関連広域テスト: 66/66 PASS
- [x] alias回帰テスト: 1/1 PASS（copy無しFAIL / copyありPASS）
- [x] post-check 2本: Critical 0
- [x] checks-final: confirmed 0

Web変更はなく、スクリーンショットは不要です。

Generated with Codex
