### PR TITLE
fix: 鉱脈確定snapshotを現在タイルへ局所化

### DIFF
--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/AssemblyInfo.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Server.Tests")]

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/AssemblyInfo.cs.meta
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8642b47b5c5054995ad89af8a9a9ae6e

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/FluidVeinPlacementStage.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/FluidVeinPlacementStage.cs
@@ -24,7 +24,8 @@ namespace Game.MapGeneration.Pipeline.Stages
             var placement = VeinPlacementCore.Generate(
                 ore.fluidEntries, ore.borderMargin,
                 config, masks, biomeTypes, heights2D, treeEntries, objectPlacements,
-                FluidVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(),
+                FluidVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(
+                    config.worldOffsetX, config.worldOffsetZ, config.terrainWidth, config.terrainLength),
                 tile, tile.Halo.FluidVeinMembers, tile.Halo.FluidVeinCenters);
             tile.Halo.CommitFluidVeins(placement);
             return placement.Veins;

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/OrePlacementStage.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/OrePlacementStage.cs
@@ -21,7 +21,8 @@ namespace Game.MapGeneration.Pipeline.Stages
             var placement = VeinPlacementCore.Generate(
                 ore.entries, ore.borderMargin,
                 config, masks, biomeTypes, heights2D, treeEntries, objectPlacements,
-                ItemVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(),
+                ItemVeinRngSeedOffset, tile.Halo.CreateConfirmedVeinSnapshot(
+                    config.worldOffsetX, config.worldOffsetZ, config.terrainWidth, config.terrainLength),
                 tile, tile.Halo.ItemVeinMembers, tile.Halo.ItemVeinCenters);
             tile.Halo.CommitItemVeins(placement);
             return placement.Veins;

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinAabbBuilder.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Stages/Vein/VeinAabbBuilder.cs
@@ -20,5 +20,21 @@ namespace Game.MapGeneration.Pipeline.Stages
                 Max = center + Extent,
             };
         }
+
+        // タイル内で生成可能な全AABBの範囲へ履歴が届くか判定する。
+        // Tests whether history can reach the bounds of any AABB producible inside the tile.
+        internal static bool CanOverlapAnyCandidateInTile(
+            PlacedVein history, float tileWorldOffsetX, float tileWorldOffsetZ,
+            float tileWidth, float tileLength)
+        {
+            int possibleMinX = Mathf.CeilToInt(tileWorldOffsetX) - Extent.x;
+            int possibleMaxX = Mathf.CeilToInt(tileWorldOffsetX + tileWidth) - 1 + Extent.x;
+            int possibleMinZ = Mathf.CeilToInt(tileWorldOffsetZ) - Extent.z;
+            int possibleMaxZ = Mathf.CeilToInt(tileWorldOffsetZ + tileLength) - 1 + Extent.z;
+
+            if (history.Max.x < possibleMinX || possibleMaxX < history.Min.x) return false;
+            if (history.Max.z < possibleMinZ || possibleMaxZ < history.Min.z) return false;
+            return true;
+        }
     }
 }

--- a/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
+++ b/moorestech_server/Assets/Scripts/Game.MapGeneration/Pipeline/Tiling/PlacementHaloStore.cs
@@ -30,9 +30,20 @@ namespace Game.MapGeneration.Pipeline.Tiling
 
         // 先行タイルと先行種別の確定AABBを後着鉱脈の排他入力にする。
         // Snapshots confirmed AABBs from earlier tiles and kinds for later-vein exclusion.
-        internal List<PlacedVein> CreateConfirmedVeinSnapshot()
+        internal List<PlacedVein> CreateConfirmedVeinSnapshot(
+            float tileWorldOffsetX, float tileWorldOffsetZ,
+            float tileWidth, float tileLength)
         {
-            return new List<PlacedVein>(_confirmedVeins);
+            // 遠隔履歴を候補範囲で除外する。
+            // Excludes remote history that cannot touch any candidate AABB in this tile.
+            var snapshot = new List<PlacedVein>();
+            foreach (var vein in _confirmedVeins)
+            {
+                if (!VeinAabbBuilder.CanOverlapAnyCandidateInTile(
+                        vein, tileWorldOffsetX, tileWorldOffsetZ, tileWidth, tileLength)) continue;
+                snapshot.Add(vein);
+            }
+            return snapshot;
         }
 
         internal void CommitItemVeins(ConfirmedVeinPlacementBatch placement)

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/PlacementHaloStoreTest.cs
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/PlacementHaloStoreTest.cs
@@ -1,0 +1,53 @@
+using System.Linq;
+using Game.MapGeneration.Pipeline;
+using Game.MapGeneration.Pipeline.Config;
+using Game.MapGeneration.Pipeline.Stages;
+using Game.MapGeneration.Pipeline.Tiling;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Tests.UnitTest.Game.MapGeneration.Tiling
+{
+    public class PlacementHaloStoreTest
+    {
+        [Test]
+        public void 確定鉱脈snapshotは現在タイルの候補AABBへ届く履歴だけを返す()
+        {
+            var store = new PlacementHaloStore(10f);
+            var placement = new ConfirmedVeinPlacementBatch();
+
+            // 四辺の接触を残し遠隔履歴を除く。
+            // Keeps touching history on every edge while excluding history one cell farther away.
+            placement.Veins.Add(CreateVein("touch-left", new Vector3Int(97, 0, 110), new Vector3Int(99, 2, 112)));
+            placement.Veins.Add(CreateVein("touch-right", new Vector3Int(150, 0, 120), new Vector3Int(152, 2, 122)));
+            placement.Veins.Add(CreateVein("touch-lower-z", new Vector3Int(120, 0, 97), new Vector3Int(122, 2, 99)));
+            placement.Veins.Add(CreateVein("touch-upper-z", new Vector3Int(120, 0, 150), new Vector3Int(122, 2, 152)));
+            placement.Veins.Add(CreateVein("inside", new Vector3Int(120, 1000, 130), new Vector3Int(122, 1002, 132)));
+            placement.Veins.Add(CreateVein("far-left", new Vector3Int(96, 0, 110), new Vector3Int(98, 2, 112)));
+            placement.Veins.Add(CreateVein("far-right", new Vector3Int(151, 0, 120), new Vector3Int(153, 2, 122)));
+            placement.Veins.Add(CreateVein("far-lower-z", new Vector3Int(120, 0, 96), new Vector3Int(122, 2, 98)));
+            placement.Veins.Add(CreateVein("far-upper-z", new Vector3Int(120, 0, 151), new Vector3Int(122, 2, 153)));
+            store.CommitItemVeins(placement);
+
+            var snapshot = store.CreateConfirmedVeinSnapshot(100f, 100f, 50f, 50f);
+
+            CollectionAssert.AreEquivalent(
+                new[] { "touch-left", "touch-right", "touch-lower-z", "touch-upper-z", "inside" },
+                snapshot.Select(vein => vein.VeinGuid));
+
+            #region Internal
+
+            PlacedVein CreateVein(string veinGuid, Vector3Int min, Vector3Int max)
+            {
+                return new PlacedVein
+                {
+                    VeinGuid = veinGuid,
+                    Min = min,
+                    Max = max,
+                };
+            }
+
+            #endregion
+        }
+    }
+}

--- a/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/PlacementHaloStoreTest.cs.meta
+++ b/moorestech_server/Assets/Scripts/Tests/UnitTest/Game/MapGeneration/Tiling/PlacementHaloStoreTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e4a01a292d8064c2aa2a7add4918fa5e


### PR DESCRIPTION
## 概要

- #1259 の EditMode CI timeout を前方修正します。
- 確定済み鉱脈AABBの全履歴を各候補へ渡す処理を、現在タイルの候補AABBへXZ方向に到達できる履歴だけのsnapshotへ局所化します。
- AABB生成規則は既存裁定どおり `Extent = (1, 1, 1)` を維持し、`Extent` 自体はprivateのままです。

## 根因

3x3生成の終盤で確定履歴が3,132件まで増え、1候補ごとに全履歴を走査した結果、1種別だけで585,513比較に増幅していました。#1259 のCIではMapGeneration 272件が約2,562秒から約3,679秒へ悪化し、従来成功していた4件が180秒timeoutへ到達しました。

## 修正

- タイル内で生成可能な整数スナップ中心の範囲を `Ceil(offset)` 〜 `Ceil(offset + size) - 1` として求めます。
- 固定AABB余白を加えたXZ範囲へ届かない履歴をsnapshot作成時に1回だけ除外します。
- Yは除外せず、履歴順も維持するため、配置結果と決定論は変えません。
- 四辺の接触境界と四方向の遠隔除外を直接テストします。

## 検証

- [x] Unity compile: Error 0 / Warning 0
- [x] Vein/Tiling関連: 39/39 PASS
- [x] #1259 CI timeout対象: 4/4 PASS（合計約97秒）
- [x] 分岐変異: 条件除去で1/1 FAIL、復元で1/1 PASS
- [x] 増分レビュー2系統: Critical 0 / Warning 0
- [x] moores-code-review機械判定: confirmed 0 / 規約候補0

Web変更はなく、スクリーンショットは不要です。

Generated with Codex
