### PR TITLE
fix: PR #1302で崩れたコンパイルを追随させ日次ビルドを戻す

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Localization/_CompileRequester.cs
+++ b/moorestech_client/Assets/Scripts/Client.Localization/_CompileRequester.cs
@@ -5,5 +5,5 @@ public class LocalizationCompileRequester
 {
 // CSV更新時はこの印もcommit
 // Commit this marker with CSV changes
-    private const string dummyText = "C6-B1-54-E8-62-66-02-FA-C2-CB-21-47-84-3C-30-A8";
+    private const string dummyText = "32-29-EC-E1-3E-E0-EE-61-0F-16-01-4C-1D-98-E4-4A";
 }

--- a/moorestech_client/Assets/Scripts/Client.Tests/Interact/BlockInteractableTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Interact/BlockInteractableTest.cs
@@ -61,7 +61,7 @@ namespace Client.Tests.Interact
             var blockGuid = openable.GetComponent<BlockGameObject>().BlockMasterElement.BlockGuid;
             Assert.AreEqual(new[] { Localize.GetContent(ContentLocalizationKeys.BlockName(blockGuid)) }, openable.Actions[0].HintParams);
 
-            var transit = openable.Actions[0].Execute();
+            var transit = openable.Actions[0].Execute().TransitContext;
             Assert.AreEqual(UIStateEnum.SubInventory, transit.NextStateEnum);
             Assert.IsInstanceOf<BlockSubInventorySource>(transit.GetContext<ISubInventorySource>());
         }

--- a/moorestech_client/Assets/Scripts/Client.Tests/Interact/InteractTargetSelectorTestFixture.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Interact/InteractTargetSelectorTestFixture.cs
@@ -122,7 +122,7 @@ namespace Client.Tests.Interact
             targetObject.transform.position = position;
             targetObject.AddComponent<SphereCollider>().radius = 0.05f;
             var mapObject = targetObject.AddComponent<MapObjectGameObject>();
-            targetObject.AddComponent<MapObjectRayTarget>().Initialize(mapObject);
+            targetObject.AddComponent<MapObjectRayTarget>().Initialize(mapObject, interactable: true);
 
             // マスタ解決済みのmapObjectだけが選定対象になるため、実マスタの要素を載せる
             // Only a map object with a resolved master is selectable, so put a real master element on it

--- a/moorestech_client/Assets/Scripts/Client.Tests/Interact/TrainCarInteractableTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/Interact/TrainCarInteractableTest.cs
@@ -41,7 +41,7 @@ namespace Client.Tests.Interact
         {
             var interactable = CreateTrainCarInteractable();
 
-            var transit = interactable.Actions[0].Execute();
+            var transit = interactable.Actions[0].Execute().TransitContext;
 
             Assert.AreEqual(UIStateEnum.SubInventory, transit.NextStateEnum);
             Assert.IsInstanceOf<TrainSubInventorySource>(transit.GetContext<ISubInventorySource>());
@@ -53,7 +53,7 @@ namespace Client.Tests.Interact
             var trainCarEntityObject = CreateTrainCarEntityObject();
             var interactable = AttachTrainCarInteractable(trainCarEntityObject);
 
-            var transit = interactable.Actions[1].Execute();
+            var transit = interactable.Actions[1].Execute().TransitContext;
 
             Assert.AreEqual(UIStateEnum.TrainHUDScreen, transit.NextStateEnum);
             var request = transit.GetContext<RideTrainCarRequest>();

--- a/moorestech_client/Assets/Scripts/Editor/MapObjectWrapperGenerator/WrapperPrefabFactory.cs
+++ b/moorestech_client/Assets/Scripts/Editor/MapObjectWrapperGenerator/WrapperPrefabFactory.cs
@@ -7,6 +7,7 @@ using Client.Game.InGame.Map.MapObject;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Rendering;
+using UnityEngine.SceneManagement;
 
 // BKへアウトライン・レイターゲット・HPバーを付与
 // Builds one wrapper prefab: BK plus its outline, ray target, and HP bar

--- a/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
+++ b/moorestech_server/Assets/Scripts/Core.Master/_CompileRequester.cs
@@ -1,8 +1,9 @@
+
 // SchemaWatcher更新用の再compile印
 // Recompile marker updated by SchemaWatcher
 public class CompileRequester
 {
 // スキーマ更新時はこの印もcommit
 // Commit this marker with schema changes
-    private const string dummyText = "96-EB-25-28-3C-6A-43-4C-8C-71-3E-17-C9-B7-DE-03";
+    private const string dummyText = "07-22-A0-AB-69-93-F1-78-B5-1A-F4-F2-A0-96-BA-FE";
 }


### PR DESCRIPTION
Fixes #1305

## 何が壊れていたか

日次ビルド（`Client Build - StandaloneWindows64` / `StandaloneOSX`）が head `4a8ad4cb` で赤。
原因は PR #1302（interact-key-unification）の本体変更にテスト側が追随していなかったこと。

| エラー | 箇所 | 由来 |
| --- | --- | --- |
| CS1061 `InteractExecuteResult` に `NextStateEnum` / `GetContext` が無い | `TrainCarInteractableTest.cs` (46,47,58,59) / `BlockInteractableTest.cs` (65,66) | F15 で `ITapInteractAction.Execute()` の戻りが `UITransitContext` から `InteractExecuteResult` へ変わった |
| CS7036 `MapObjectRayTarget.Initialize` の必須引数 `interactable` が無い | `InteractTargetSelectorTestFixture.cs` (125) | `Initialize(MapObjectGameObject, bool)` へ引数が増えた |

加えて、ローカルコンパイルで Editor アセンブリが落ちることが判明した。
`6825bfc91`（PR #1302 のレビュー指摘適用コミット）が `WrapperPrefabFactory.cs` から
`using UnityEngine.SceneManagement;` を落としており、`Scene workScene` 引数が
CS0246 で解決できない。player build には Editor asmdef が入らないため CI では表面化して
いなかったが、master 上の実コンパイルエラーなので同時に戻す。

## 何を直したか

- `TrainCarInteractableTest` / `BlockInteractableTest`: `Execute()` の戻りを
  `.TransitContext` 経由で受けるようにした（実行結果の中身は変えていない）
- `InteractTargetSelectorTestFixture`: `Initialize(mapObject, interactable: true)`。
  選定対象として作るフィクスチャなので `true`（`OutcropMiningAimTest` の既存呼び出しと同形）
- `WrapperPrefabFactory`: `using UnityEngine.SceneManagement;` を復帰

## 検証

`uloop compile --project-path ./moorestech_client` → `Success: true` / Errors 0 / Warnings 0。

`Client.Tests.Interact.*` の実行は **master 由来の別不具合でSetUpが落ちるため通せていない**。
`MasterHolder.Load` が `BlockMaster` を先に Validate するのに対し `MasterHolder.MapObjectMaster`
の代入はその後ろのため、`BlockMasterUtil.MapObjectMineSettingsValidation`（`002bb199a` で追加）が
null 参照で落ちる。本PRの変更とは独立で、日次ビルド（コンパイルのみ）には影響しない。
詳細は #1305 にコメントで残した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QYbLTS1Z3QxH1injxVcEAU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated interaction handling to correctly access results when opening inventories, entering vehicles, and triggering block actions.
  - Improved interaction target selection by explicitly identifying interactable map objects.

- **Tests**
  - Updated interaction tests to reflect the latest action execution behavior.

- **Chores**
  - Refreshed internal compilation markers and editor support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->