### PR TITLE
fix: Environment.prefabのOtherEnvironmentへOtherRootインスタンスを戻す

### DIFF
--- a/.decisions/2026-09-04-固定地形5x5の復旧はいったん止めて現状維持する.md
+++ b/.decisions/2026-09-04-固定地形5x5の復旧はいったん止めて現状維持する.md
@@ -1,0 +1,36 @@
+# 固定地形5x5の復旧はいったん止めて現状維持する
+
+決定日: 2026-09-04
+出所: ユーザー裁定 2026-09-04 原文「これを進めて」→ 再生成完了後に判明した2つの障害を提示し、選択「いったん止めて現状維持」を採択
+
+決定:
+
+デバッグ環境Other用の固定地形（`GeneratedTerrain5x5.prefab` が参照する25枚のTerrainData）の復旧を止め、地形は欠損のまま残す。
+`Environment.prefab` への `OtherRoot` インスタンス復帰だけを入れる。
+
+理由:
+
+消失した25枚そのものは戻らないが、生成器（`TmpUnityPjt/MapMaking` の `InfiniteTerrainManager` + `SceneOnlyTerrainExporter`）は残っており、
+再生成と書き出しは実際に成功した（当時と同じファイル名・`spawnWorldPosition` も当時の `(2116.70, -807.62)` と一致）。
+そのうえで2点の障害が出た。
+
+1. **当時と同一の地形にはならない。** 生成器がプレハブのコミット時（2026-06-02/04）から進化しており、同 seed でも配置数が違う
+   （オブジェクト 1,986 → 8,295 / 鉱脈 2,635 → 2,249）。`TerrainGenerator` は樹木・岩の後処理で heightmap と splatmap を書き換えるため
+   地表そのものが別物になり、クライアント側の既存 `MapGenerator_Objects.prefab` / `MapGenerator_Ores.prefab` と不整合になる。
+2. **容量が3.6GB**（1枚約150MB、2048 alphamap × 24レイヤー＋24 detailレイヤー＋樹木76,815本）。
+   `moorestech-client-private` は LFS 未使用で `.git` が既に16GBあり、素の push は GitHub のパック上限に当たる。
+
+固定地形が要る理由（起動が速い／毎回同じ地形でデバッグしたい）に対し、再生成物は当時と同じ地形ではないため固定地形としての価値が目減りしている。
+その状態で3.6GBを private repo へ恒久的に積むのは割に合わない。方針（固定維持 or ランタイム一本化）を決めてから動く。
+
+棄却案:
+
+- **3点セット（25枚＋Objects＋Ores）を差し替えて client-private に LFS を導入し push** — 却下。固定地形は維持できるが
+  private repo が恒久的に3.6GB膨らむ。復元しても「当時の地形」ではないため膨張のコストに見合わない。
+- **alphamap解像度・レイヤー数を削って容量を落としてから差し替え** — 却下。見た目が落ちるうえ、理由1の不整合は解決しない。
+- **ランタイム生成へ一本化して Other を捨てる**（`638b4789d` の方針） — 恒久解としては有力だが、今回は判断を保留。
+
+リンク:
+
+- bd: `moorestech-87s`（再生成の再現手順は同issueのnoteに記録）
+- 移行記録: `../moorestech_logs/map/MapMaking-RestoreManifest/README.md`

--- a/moorestech_client/Assets/Asset/Common/Prefab/Environment/Environment.prefab
+++ b/moorestech_client/Assets/Asset/Common/Prefab/Environment/Environment.prefab
@@ -77,7 +77,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 6470292548264755296}
   m_Father: {fileID: 1737230499573010102}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1288147543743196992
@@ -236,6 +237,68 @@ Transform:
   - {fileID: 3695114482357105121}
   m_Father: {fileID: 1737230499573010102}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1659596175667470058
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 621468631813163166}
+    m_Modifications:
+    - target: {fileID: 3048381035448689459, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_Name
+      value: OtherRoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+--- !u!4 &6470292548264755296 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5675390020361133706, guid: 0d5c9dbb8a2ad4473afbc3eafc1a1c90, type: 3}
+  m_PrefabInstance: {fileID: 1659596175667470058}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4334807476762743262
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 概要

`f71a8e710` で `Environment.prefab` の `OtherEnvironment` 配下を `OtherRoot.prefab` へ切り出した際にインスタンスを戻し忘れ、`OtherEnvironment` が空になっていた。インスタンスを戻す。

## 5x5固定地形のTerrainData欠損について（本PRでは直さない）

同じ症状（デバッグ環境Otherの地形が出ない / bd `moorestech-87s`）のもう一方の原因である、`GeneratedTerrain5x5.prefab` が参照するTerrainData 25枚の欠損は**本PRでは解消しない**。調査の結果、再生成自体は成功したが以下2点で保留とした（裁定を `.decisions/` に記録）。

1. **当時と同一の地形にはならない。** 生成器がプレハブのコミット時（2026-06-02/04）から進化しており、同 seed でも配置数が違う（オブジェクト 1,986 → 8,295 / 鉱脈 2,635 → 2,249）。`TerrainGenerator` は樹木・岩の後処理で heightmap と splatmap を書き換えるため地表そのものが別物になり、既存の `MapGenerator_Objects.prefab` / `MapGenerator_Ores.prefab` と不整合になる
2. **容量が3.6GB**（1枚約150MB）。`moorestech-client-private` は LFS 未使用で `.git` が既に16GBあり、素の push は GitHub のパック上限に当たる

再生成の再現手順と落とし穴は bd `moorestech-87s` の note に記録済み。

## 変更

- `moorestech_client/Assets/Asset/Common/Prefab/Environment/Environment.prefab` — `OtherRoot` インスタンスを復帰
- `.decisions/2026-09-04-固定地形5x5の復旧はいったん止めて現状維持する.md` — 裁定を記録（棄却案つき）

## テスト

Prefabの変更のみのためテストは新設していない（AGENTS.md の方針に従う）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2MWXAioBuzvTEPjawipJG