### PR TITLE
fix: logs-syncのmtime比較をms切り捨てにし全ミラーファイルの毎回再コピーを止める

### DIFF
--- a/.dev-hooks/logs-sync.mjs
+++ b/.dev-hooks/logs-sync.mjs
@@ -154,7 +154,9 @@ function copyIfUpdated(src, dest) {
     // Skip files over GitHub's 100MB limit; they can never be pushed.
     if (srcStat.size > 95 * 1024 * 1024) return;
     if (existsSync(dest)) {
-      if (srcStat.mtimeMs <= statSync(dest).mtimeMs) return;
+      // utimesSyncはms精度でしか書けずAPFSのns精度mtimeに常に負けるため、ms切り捨てで比較する
+      // utimesSync writes ms precision and always loses to APFS ns mtimes, so compare at floored ms.
+      if (Math.floor(srcStat.mtimeMs) <= Math.floor(statSync(dest).mtimeMs)) return;
     } else if (Date.now() - srcStat.mtimeMs > 7 * 24 * 3600 * 1000) {
       return;
     }


### PR DESCRIPTION
## 症状
SSD書き込みが1日平均257GB（`ssd-write-log`の14日計測、年換算92TB）。稼働時間帯は毎時15〜65GB、無人時は毎時1.1〜1.3GB。

## 原因
`.dev-hooks/logs-sync.mjs` の `copyIfUpdated` は宛先へ `utimesSync(dest, atime, mtime)` でsourceのmtimeを書き戻すが、Node側はms精度、APFS側はns精度のため `dest.mtime < src.mtime` が常に成立し、宛先が存在する全ファイルを毎回再コピーしていた。

実測（ミラー全体の述語シミュレーション）:
| 述語 | コピー対象 |
| --- | --- |
| 現行 `src.mtimeMs <= dest.mtimeMs` | 8,493件 / 1,555MB |
| 修正 `floor(ms)` 比較 | 12件 / 5MB |

5分間サンプルでは `logs-sync.mjs` 1プロセスが1.24GB書き込み（窓全体2.0GBの62%）。hookはStop/SessionEndごとに90秒スロットルで走るため、稼働時間帯は毎時20〜30回 × 1.5GB ≒ 毎時30〜50GB。

## 修正
mtime比較をms切り捨て（`Math.floor`）で行う。実行1回の書き換え: 8,505件/1.58GB → 11件/2.7MB。

## 検証
- `node --check` 通過
- 修正版を実データに対して1回実行し、ctimeで書き換えファイルを計測（上記）

Beads: moorestech-c627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DA5DZnRkVCtFp8PspikS7
