### PR TITLE
fix(ci): game-ci actions を動作実績のあるSHAへピン留めしCI全滅を復旧

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,9 @@ jobs:
       # The daily build runs cold so the 10GB cache budget goes to PR-side jobs (ADR 0028)
       # Build
       - name: Server Build - ${{ matrix.platform.name }}
-        uses: game-ci/unity-builder@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-builder@4423ee75828dff56037d1d1cfdac6b68e3a6ba00 # v4.8.2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -275,7 +277,9 @@ jobs:
       # The daily build runs cold so the 10GB cache budget goes to PR-side jobs (ADR 0028)
       # Build
       - name: Client Build - ${{ matrix.platform.name }}
-        uses: game-ci/unity-builder@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-builder@4423ee75828dff56037d1d1cfdac6b68e3a6ba00 # v4.8.2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -86,7 +86,9 @@ jobs:
       # Import only, without running any test, since the goal is to produce the Library
       - name: Warm Library
         id: warm
-        uses: game-ci/unity-test-runner@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -183,7 +185,9 @@ jobs:
 
       - name: Warm Library - ${{ matrix.target }}
         id: warm
-        uses: game-ci/unity-builder@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-builder@4423ee75828dff56037d1d1cfdac6b68e3a6ba00 # v4.8.2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/platform-compile.yml
+++ b/.github/workflows/platform-compile.yml
@@ -50,7 +50,9 @@ jobs:
       # buildMethodはプレイヤービルドをせず終了するため、実質「そのdefineでコンパイルが通るか」の検査になる
       # The buildMethod exits without building a player, so this effectively checks compilation under those defines
       - name: Compile check - ${{ matrix.target }}
-        uses: game-ci/unity-builder@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-builder@4423ee75828dff56037d1d1cfdac6b68e3a6ba00 # v4.8.2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}

--- a/.github/workflows/run_test.yml
+++ b/.github/workflows/run_test.yml
@@ -172,7 +172,9 @@ jobs:
       # 専用fixtureはCategoryだけ、残余は検証済みassemblyも併用し、網羅性を保って探索固定費を抑える。
       # Use categories alone for dedicated fixtures and verified assemblies for remainders to retain coverage with lower discovery overhead.
       - name: Run Unity Test - ${{ matrix.shard }}
-        uses: game-ci/unity-test-runner@v4
+        # 上流がv4タグを動かしCIが全滅したため、動作実績のあるSHAへ固定する（2026-09-09）
+        # Pinned to a known-good SHA because an upstream v4 tag move broke all CI (2026-09-09)
+        uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4.3.1
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}


### PR DESCRIPTION
## 何が起きていたか

2026-09-09 07:32Z 以降、**全PRの Unity Test 10ジョブが一斉に失敗**していた（PR #1335 / #1336 を含む）。失敗ログはテスト結果ですらなく、docker を起動する前の一行:

```
sh: 1: Syntax error: "&" unexpected
[ERROR] Error: sh: 1: Syntax error: "&" unexpected
##[error]Test run failed with exit code 1
```

## 原因

上流 `game-ci/unity-test-runner` が **2026-09-09 01:06Z に v4.4.0 を公開し、`v4` タグを移動した**。

| | SHA | 中身 |
| --- | --- | --- |
| 09-08 19:11 の成功時 | `0ff419b9` (v4.3.1) | Action が直接 `docker run` する従来実装 |
| 09-09 07:32 以降の失敗時 | `32e5771` (v4.4.0) | 処理を `game-ci` CLI バイナリへ委譲する新実装 |

新実装が組み立てる `sh -c` コマンドがこの環境で構文エラーになり、Unity へ到達する前に exit 1 する。**PRのコード内容とは完全に無関係**な上流由来の全断だった。

## 対応

- `unity-test-runner` を、最後に成功した実績のある **v4.3.1 の SHA へ固定**
- `unity-builder` も同じタグ移動の事故に晒されているため、**現在解決されるのと同じ v4.8.2 の SHA へ固定**（挙動は現状と同一で、無防備なタグ追従だけをやめる）

対象: `run_test.yml` / `cache-warm.yml` / `platform-compile.yml` / `build.yml`

## 検証

- 全 workflow yml の YAML パース OK
- このPR自身の Unity Test が緑になることが、そのまま復旧の証明になる

Refs: moorestech-er38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CmRmu1Bc22tFWK7i49nX4D