### PR TITLE
fix: PlayMode停止後の初期化継続がEditModeで再開しServerInstanceが残留する穴を塞ぐ

### DIFF
--- a/moorestech_client/Assets/Scripts/Client.Starter/Editor/ServerInstanceResidueEditorCleanup.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/Editor/ServerInstanceResidueEditorCleanup.cs
@@ -1,0 +1,45 @@
+#if UNITY_EDITOR
+using Server.Boot;
+using UnityEditor;
+using UnityEngine;
+
+namespace Client.Starter.Editor
+{
+    /// <summary>
+    /// Editor 専用の保険: Play 終了後に再開した初期化継続が編集中シーンへ残した ServerStarter を、次の Play が始まる前に除去する
+    /// 本線は exitCancellationToken と生成直前の fail-closed ガード。ここは両方をすり抜けた残留が次の Play で引数なしサーバーとして起動するのを止める最後の網
+    /// Editor-only safety net: removes ServerStarter objects that a resumed initialization left in the edited scene before the next play session starts
+    /// The primary defenses are exitCancellationToken and the fail-closed guard before creation; this last net stops a leaked object from booting an argument-less server on the next play
+    /// </summary>
+    public static class ServerInstanceResidueEditorCleanup
+    {
+        //   - EnteredEditMode: Play 終了直後にすでに再開していた継続の残留を拾う
+        //   - ExitingEditMode: 遅れて再開した継続の残留を、シーンが Play 用に退避される前に拾う
+        //   - EnteredEditMode: catches residue from a continuation that already resumed right after play-mode exit
+        //   - ExitingEditMode: catches residue from a late continuation before the scene is backed up for play
+        [InitializeOnLoadMethod]
+        private static void RegisterPlayModeHook()
+        {
+            EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
+        }
+
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            if (state != PlayModeStateChange.EnteredEditMode && state != PlayModeStateChange.ExitingEditMode) return;
+            RemoveResidueFromLoadedScenes();
+        }
+
+        private static void RemoveResidueFromLoadedScenes()
+        {
+            // EditMode で見つかる ServerStarter は正規経路では存在し得ない。Play 中の生成物は DontDestroyOnLoad ごと Play 終了で消えるため
+            // No ServerStarter can legitimately exist in EditMode: play-time instances vanish with DontDestroyOnLoad on play-mode exit
+            var residues = Object.FindObjectsByType<ServerStarter>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+            foreach (var residue in residues)
+            {
+                Debug.LogWarning($"[ServerInstanceResidueEditorCleanup] 編集中シーン '{residue.gameObject.scene.name}' に残留した ServerInstance を除去します");
+                Object.DestroyImmediate(residue.gameObject);
+            }
+        }
+    }
+}
+#endif

--- a/moorestech_client/Assets/Scripts/Client.Starter/Editor/ServerInstanceResidueEditorCleanup.cs.meta
+++ b/moorestech_client/Assets/Scripts/Client.Starter/Editor/ServerInstanceResidueEditorCleanup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3a9748c0241ee4f3eadb238cdfa9f6b1

--- a/moorestech_client/Assets/Scripts/Client.Starter/Initialization/ServerConnectionInitializer.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/Initialization/ServerConnectionInitializer.cs
@@ -23,12 +23,14 @@ namespace Client.Starter.Initialization
         private readonly InitializeProprieties _proprieties;
         private readonly LoadingProgressLog _loadingProgressLog;
         private readonly PlayerConnectionSetting _playerConnectionSetting;
+        private readonly CancellationToken _exitToken;
 
-        public ServerConnectionInitializer(InitializeProprieties proprieties, LoadingProgressLog loadingProgressLog, PlayerConnectionSetting playerConnectionSetting)
+        public ServerConnectionInitializer(InitializeProprieties proprieties, LoadingProgressLog loadingProgressLog, PlayerConnectionSetting playerConnectionSetting, CancellationToken exitToken)
         {
             _proprieties = proprieties;
             _loadingProgressLog = loadingProgressLog;
             _playerConnectionSetting = playerConnectionSetting;
+            _exitToken = exitToken;
         }
 
         public async UniTask<ServerConnectionResult> RunAsync()
@@ -52,7 +54,7 @@ namespace Client.Starter.Initialization
 
             //最初に必要なデータを取得
             // Fetch the initial data bundle
-            var handshakeResponse = await vanillaApi.Response.InitialHandShake(_playerConnectionSetting.PlayerId, default);
+            var handshakeResponse = await vanillaApi.Response.InitialHandShake(_playerConnectionSetting.PlayerId, _exitToken);
 
             _loadingProgressLog.AppendElapsed(LocalizationKeys.Ui.Loading.InitialDataFetched);
 
@@ -70,12 +72,16 @@ namespace Client.Starter.Initialization
                 {
                     var serverProperties = new ConnectionServerProperties(_proprieties.ServerIp, _proprieties.RemoteServerPort.Value);
 
-                    // タイムアウト時に接続タスクとソケットを道連れに畳む
-                    // Fold the connection task and its socket together on timeout
-                    using var remoteConnectWait = new CancellationTokenSource();
+                    // タイムアウトとPlay終了のどちらでも接続タスクとソケットを道連れに畳む
+                    // Fold the connection task and its socket together on timeout or play-mode exit
+                    using var remoteConnectWait = CancellationTokenSource.CreateLinkedTokenSource(_exitToken);
                     return await ServerCommunicator.CreateConnectedInstance(serverProperties, remoteConnectWait.Token)
                         .Timeout(timeOut, taskCancellationTokenSource: remoteConnectWait);
                 }
+
+                // Play終了後に再開した継続が編集中シーンへサーバーを生成しないよう、生成直前でfail-closedにする
+                // Fail closed right before creation so a continuation resumed after play-mode exit never spawns a server into the edited scene
+                if (!Application.isPlaying) throw new OperationCanceledException("ServerInstance creation aborted because play mode has already exited.");
 
                 // ローカルは試行せず内蔵サーバー起動
                 // Local boots the embedded server without probing
@@ -95,14 +101,14 @@ namespace Client.Starter.Initialization
 
                 // バインド後に実ポートへ接続。タイムアウト時も述語をPlayerLoopに残さない
                 // Connect to the assigned port after binding, leaving no predicate in the PlayerLoop on timeout
-                using var boundPortWait = new CancellationTokenSource();
+                using var boundPortWait = CancellationTokenSource.CreateLinkedTokenSource(_exitToken);
                 await UniTask.WaitUntil(() => serverStarter.BoundPort != 0, PlayerLoopTiming.Update, boundPortWait.Token)
                     .Timeout(TimeSpan.FromSeconds(60), taskCancellationTokenSource: boundPortWait);
                 var localServerProperties = new ConnectionServerProperties(_proprieties.ServerIp, serverStarter.BoundPort);
 
                 // ローカル接続も同じくタイムアウトでタスクとソケットを残さない
                 // The local connection likewise leaves no task or socket behind on timeout
-                using var localConnectWait = new CancellationTokenSource();
+                using var localConnectWait = CancellationTokenSource.CreateLinkedTokenSource(_exitToken);
                 return await ServerCommunicator.CreateConnectedInstance(localServerProperties, localConnectWait.Token)
                     .Timeout(timeOut, taskCancellationTokenSource: localConnectWait);
             }

--- a/moorestech_client/Assets/Scripts/Client.Starter/Initialization/TerrainDataFetcher.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/Initialization/TerrainDataFetcher.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Threading;
 using Client.Network.API;
 using Cysharp.Threading.Tasks;
 using Game.MapGeneration.Transfer;
@@ -18,10 +19,12 @@ namespace Client.Starter.Initialization
     public class TerrainDataFetcher
     {
         private readonly VanillaApiWithResponse _vanillaApiWithResponse;
+        private readonly CancellationToken _exitToken;
 
-        public TerrainDataFetcher(VanillaApiWithResponse vanillaApiWithResponse)
+        public TerrainDataFetcher(VanillaApiWithResponse vanillaApiWithResponse, CancellationToken exitToken)
         {
             _vanillaApiWithResponse = vanillaApiWithResponse;
+            _exitToken = exitToken;
         }
 
         // 戻り値は実際に取得したチャンク数。0はキャッシュヒットまたは地形なしワールドを意味する
@@ -87,7 +90,7 @@ namespace Client.Starter.Initialization
 
             async UniTask<byte[]> FetchChunk(int chunkIndex)
             {
-                var response = await _vanillaApiWithResponse.GetTerrainChunk(chunkIndex, default);
+                var response = await _vanillaApiWithResponse.GetTerrainChunk(chunkIndex, _exitToken);
 
                 // サーバーが例外を投げた場合は応答が届かず、PacketExchangeManagerのタイムアウトでnullが返る
                 // When the server throws, no response arrives and PacketExchangeManager's timeout surfaces it as null

--- a/moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs
+++ b/moorestech_client/Assets/Scripts/Client.Starter/InitializeScenePipeline.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading;
 using Client.Common;
 using Client.Game.Common;
 using Client.Game.InGame.Block;
@@ -50,6 +51,10 @@ namespace Client.Starter
             // A new boot sequence begins; clear the previous session's shutdown guard here
             GameShutdownEvent.ResetForNewSession();
 
+            // Play終了で各await継続を打ち切る。Task系境界の継続がEditModeで再開しシーンを汚すのを防ぐ
+            // Play-mode exit cancels every await so Task-based continuations never resume in EditMode and dirty the scene
+            var exitToken = Application.exitCancellationToken;
+
             // ---- Web UI サーバーの起動（最序盤）----
             // GameShutdownEvent の購読は WebUiHost 側で 1 度だけ張られる
             // ---- Web UI server bootstrap (earliest phase) ----
@@ -59,9 +64,9 @@ namespace Client.Starter
             // Web UI startup failure does not block gameplay, but the screen UI is web-only so nothing is shown
             try
             {
-                await Client.WebUiHost.Boot.WebUiHost.StartAsync();
+                await Client.WebUiHost.Boot.WebUiHost.StartAsync(exitToken);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
                 // WebUI 無しでゲーム続行。外部プロセス境界の起動失敗を隔離して再試行可能にする
                 // Continue without WebUI; isolate external-process startup failures and keep retries possible
@@ -93,7 +98,7 @@ namespace Client.Starter
             // Addressablesを初期化する
             // Initialize Addressables
             var initializeHandle = Addressables.InitializeAsync();
-            await initializeHandle.ToUniTask();
+            await initializeHandle.ToUniTask(cancellationToken: exitToken);
 
             // DIコンテナによるServerContextの作成
             if (!ServerContext.IsInitialized)
@@ -111,7 +116,7 @@ namespace Client.Starter
 
             // サーバー接続とアセットロードを並列実行し結果を受け取る
             // Run server connection and asset load in parallel and collect results
-            var serverInitializer = new ServerConnectionInitializer(_proprieties, loadingProgressLog, playerConnectionSetting);
+            var serverInitializer = new ServerConnectionInitializer(_proprieties, loadingProgressLog, playerConnectionSetting, exitToken);
             var modAssetLoader = new ModAssetLoader(serverDirectory, missingBlockIdObject, blockIconImagePhotographer, trainCarIconTargets, loadingProgressLog);
 
             ServerConnectionResult serverResult;
@@ -123,7 +128,7 @@ namespace Client.Starter
                 GameDictionaryComposer.Run();
                 (serverResult, assetResult) = await UniTask.WhenAll(ConnectServerThenFetchTerrainAsync(), modAssetLoader.RunAsync());
             }
-            catch (Exception e)
+            catch (Exception e) when (e is not OperationCanceledException)
             {
                 // 失敗をログとUIへ出し、文言を読ませてからメインメニューへ戻す
                 // Log the failure, surface it in the UI, and return to the main menu after the message is readable
@@ -148,6 +153,9 @@ namespace Client.Starter
             // Load the scene serially, after every asset load has finished
             // 0.9保持中は後続Addressablesロードが永久に待つため並列プリロード禁止
             // Never preload in parallel: holding at 0.9 stalls later Addressables loads forever
+            // Play終了後にここへ到達した継続はシーンロードで編集中シーンを壊すため確実に止める
+            // A continuation reaching here after play-mode exit would clobber the edited scene, so stop it for certain
+            exitToken.ThrowIfCancellationRequested();
             SceneManager.sceneLoaded += MainGameSceneLoaded;
             SceneManager.LoadSceneAsync(SceneConstant.MainGameSceneName, LoadSceneMode.Single);
 
@@ -158,7 +166,7 @@ namespace Client.Starter
             async UniTask<ServerConnectionResult> ConnectServerThenFetchTerrainAsync()
             {
                 var connectionResult = await serverInitializer.RunAsync();
-                var fetchedChunkCount = await new TerrainDataFetcher(connectionResult.VanillaApi.Response).RunAsync(connectionResult.HandshakeResponse.MapLayout);
+                var fetchedChunkCount = await new TerrainDataFetcher(connectionResult.VanillaApi.Response, exitToken).RunAsync(connectionResult.HandshakeResponse.MapLayout);
                 loadingProgressLog.AppendElapsed(LocalizationKeys.Ui.Loading.TerrainReady, fetchedChunkCount.ToString());
                 return connectionResult;
             }

--- a/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Terrain/TerrainCacheFetchTest.cs
+++ b/moorestech_client/Assets/Scripts/Client.Tests/EditModeInPlayingTest/Terrain/TerrainCacheFetchTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -65,7 +66,7 @@ namespace Client.Tests.EditModeInPlayingTest
 
                 // ② 最新キャッシュでは取得しない
                 // (2) Fetch nothing for a fresh cache
-                var terrainDataFetcher = new TerrainDataFetcher(ClientContext.VanillaApi.Response);
+                var terrainDataFetcher = new TerrainDataFetcher(ClientContext.VanillaApi.Response, CancellationToken.None);
                 var reuseFetchedCount = await terrainDataFetcher.RunAsync(mapLayout);
                 Assert.AreEqual(0, reuseFetchedCount, "キャッシュヒットなのにチャンクを取得した");
 

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/KestrelServer.cs
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/KestrelServer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Client.WebUiHost.Common;
 using Client.WebUiHost.Static;
@@ -24,10 +25,10 @@ namespace Client.WebUiHost.Boot
 
         public async Task StartAsync(WebSocketHub hub)
         {
-            await StartAsync(hub, null);
+            await StartAsync(hub, null, CancellationToken.None);
         }
 
-        public async Task StartAsync(WebSocketHub hub, WebUiStaticFileEndpoint staticFiles)
+        public async Task StartAsync(WebSocketHub hub, WebUiStaticFileEndpoint staticFiles, CancellationToken exitToken)
         {
             // 1つずつ上げてbind試行、成功で採用
             // Probe upward from the base port and adopt the first successful bind
@@ -45,7 +46,7 @@ namespace Client.WebUiHost.Boot
                 // A bind on an occupied port surfaces as IOException; try-catch here only isolates the OS network boundary
                 try
                 {
-                    await webHost.StartAsync();
+                    await webHost.StartAsync(exitToken);
                 }
                 catch (IOException)
                 {

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiHost.cs
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Boot/WebUiHost.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Client.Game.Common;
 using Client.WebUiHost.Common;
@@ -26,7 +27,9 @@ namespace Client.WebUiHost.Boot
 
         public static string WebUiUrl => _webUiUrl;
         private static string _webUiUrl;
-        public static async UniTask<bool> StartAsync()
+        // exitToken はPlay終了で発火し、Kestrel起動やVite疎通のTask継続がEditModeで再開するのを止める
+        // exitToken fires on play-mode exit and stops Kestrel startup / Vite probe continuations from resuming in EditMode
+        public static async UniTask<bool> StartAsync(CancellationToken exitToken)
         {
             // 前回の停止完了を待つ（連続 Start/Stop での自ポート衝突を避ける）
             // Wait for the previous stop to complete (avoids colliding with our own ports on rapid restart)
@@ -63,7 +66,7 @@ namespace Client.WebUiHost.Boot
                     staticFiles = new WebUiStaticFileEndpoint(WebUiPaths.ProductionDistRoot);
                 }
 
-                await kestrel.StartAsync(hub, staticFiles);
+                await kestrel.StartAsync(hub, staticFiles, exitToken);
                 kestrelStarted = true;
 
                 if (mode == WebUiHostMode.Development)
@@ -71,7 +74,7 @@ namespace Client.WebUiHost.Boot
                     vite = new ViteSupervisor();
                     // HTTP疎通後に起動成功とする
                     // A Vite instance without successful HTTP health leaves no UI, so roll it back as startup failure
-                    if (!await vite.StartAsync(kestrel.ActualPort)) return false;
+                    if (!await vite.StartAsync(kestrel.ActualPort, exitToken)) return false;
                     WebUiPortConfig.SetBrowserPort(vite.ActualPort);
                     _webUiUrl = $"http://127.0.0.1:{vite.ActualPort}/";
                 }

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Vite/ViteHealthProbe.cs
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Vite/ViteHealthProbe.cs
@@ -13,9 +13,12 @@ namespace Client.WebUiHost.Vite
     {
         private static readonly HttpClient Client = new();
 
-        public static async Task<bool> IsHealthyAsync(int port, TimeSpan timeout)
+        // exitToken による中断は「不健康」ではなく呼び出し側の打ち切りなので、falseに畳まず伝播させる
+        // Cancellation via exitToken is the caller aborting, not ill health, so it propagates instead of folding into false
+        public static async Task<bool> IsHealthyAsync(int port, TimeSpan timeout, CancellationToken exitToken)
         {
-            using var cancellation = new CancellationTokenSource(timeout);
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(exitToken);
+            cancellation.CancelAfter(timeout);
 
             // 外部HTTP障害をfalseへ隔離する
             // HTTP crosses an external-process boundary, so isolate connection failures and timeouts as false
@@ -28,7 +31,7 @@ namespace Client.WebUiHost.Vite
             {
                 return false;
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (!exitToken.IsCancellationRequested)
             {
                 return false;
             }

--- a/moorestech_client/Assets/Scripts/Client.WebUiHost/Vite/ViteSupervisor.cs
+++ b/moorestech_client/Assets/Scripts/Client.WebUiHost/Vite/ViteSupervisor.cs
@@ -21,7 +21,7 @@ namespace Client.WebUiHost.Vite
 
         public int ActualPort => _vitePort;
 
-        public async UniTask<bool> StartAsync(int kestrelPort)
+        public async UniTask<bool> StartAsync(int kestrelPort, CancellationToken exitToken)
         {
             _kestrelPort = kestrelPort;
             _process = new ViteProcess();
@@ -30,7 +30,7 @@ namespace Client.WebUiHost.Vite
 
             // HTTP応答後に起動成功とする
             // Require an HTTP response in addition to stdout ready before declaring startup success
-            if (!await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(3)))
+            if (!await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(3), exitToken))
             {
                 Debug.LogError($"[WebUiHost] Vite health check failed during startup on port {_vitePort}");
                 _process.Kill();
@@ -56,7 +56,7 @@ namespace Client.WebUiHost.Vite
                 await UniTask.Delay(ProbeIntervalMilliseconds, cancellationToken: _stopping.Token).SuppressCancellationThrow();
                 if (_stopping.IsCancellationRequested) return;
 
-                var healthy = await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(2));
+                var healthy = await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(2), CancellationToken.None);
                 consecutiveFailures = healthy ? 0 : consecutiveFailures + 1;
                 if (consecutiveFailures < FailureThreshold) continue;
 
@@ -83,7 +83,7 @@ namespace Client.WebUiHost.Vite
                 replacement.Kill();
                 return false;
             }
-            if (replacement.ActualPort != _vitePort || !await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(3)))
+            if (replacement.ActualPort != _vitePort || !await ViteHealthProbe.IsHealthyAsync(_vitePort, TimeSpan.FromSeconds(3), CancellationToken.None))
             {
                 replacement.Kill();
                 return false;


### PR DESCRIPTION
## 問題
Unity Editor でロード中に Play を Stop すると、Task 系境界（Kestrel 起動・Vite 疎通・ソケット接続など）で待っていた初期化の継続が EditMode で再開し、`ServerConnectionInitializer` が編集中シーンへ `ServerInstance` を生成する。残留物は Unity のシーンバックアップ経由で Play サイクルを越えて復元され（`isDirty=false` のまま）、次の Play で引数なし（ポート 11564・既定ワールド・AutoSave 有効）のサーバーが正規サーバーと二重に起動する。調査記録は bd `moorestech-j13b`。

## 対策（3層）
1. **本線: `Application.exitCancellationToken` を初期化フロー全体へ通す** — `InitializeScenePipeline` を起点に WebUiHost 起動・Addressables 初期化・サーバー接続・ハンドシェイク・地形取得の各 await へ渡す。`OperationCanceledException` は既存の catch をフィルタで素通しし、`Forget` 側で静かに終わる。MainGame シーンロード直前でも `ThrowIfCancellationRequested` で止める
2. **fail-closed ガード**: `ServerInstance` 生成直前で `Application.isPlaying` を確認し、Play 外なら生成しない
3. **保険の Editor フック** `ServerInstanceResidueEditorCleanup`（前例 `WebUiHostEditorCleanup` と同型）: `EnteredEditMode` / `ExitingEditMode` で編集中シーンの `ServerStarter` を除去する

`ViteHealthProbe` は exitToken による中断を「不健康 = false」へ畳まず伝播させる（false に畳むと呼び出し側が EditMode で処理を続けてしまうため）。

## 検証
- 再現レシピ（生成直前に 15 秒の `Task.Delay` を仮挿入し、Play → 5 秒後 Stop → 25 秒待機）: 継続は `isPlaying=False` で再開したが `ServerStarter` 残留 0 件・エラーログ無し
- 編集中シーンに `ServerStarter` を植えて Play: `ExitingEditMode` で除去され Play 中の個数 0（Editor.log にフックの実行記録あり）
- `TerrainCacheFetchTest` / `KestrelServerPortScanTest` 通過（2/2）
- `uloop compile` エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TGFQ4AnjhSjAHMSPXcpwdK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup cancellation when exiting Play Mode, preventing background server, web UI, terrain, and asset-loading operations from continuing afterward.
  * Prevented initialization failures from being reported when cancellation is caused by leaving Play Mode.
  * Improved web UI health checks so caller-requested cancellation is handled correctly.

* **Editor Improvements**
  * Automatically removes leaked server startup objects from scenes when returning to Edit Mode.

* **Tests**
  * Updated terrain-loading tests to support cancellation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->